### PR TITLE
add WordPress Importer plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ containers:
 | [Redirection][redirection]                               | `4.9.2`  |
 | [Tablepress][tablepress]                                 | `1.14`   |
 | [Wordfence][wordfence]                                   | `7.10.3` |
-
+| [WordPress Imorter][wp-importer]                         | `0.8.1`  |
 
 [adv-custom-fields]: https://wordpress.org/plugins/advanced-custom-fields/
 [acf-menu-chooser]: https://github.com/reyhoun/acf-menu-chooser
@@ -91,6 +91,7 @@ containers:
 [redirection]: https://wordpress.org/plugins/redirection/
 [tablepress]: https://wordpress.org/plugins/tablepress/
 [wordfence]: https://wordpress.org/plugins/wordfence/
+[wp-importer]: https://wordpress.org/plugins/wordpress-importer/
 
 
 ## Themes

--- a/config/composer/composer.json
+++ b/config/composer/composer.json
@@ -45,6 +45,7 @@
     "wpackagist-plugin/redirection": "4.9.2",
     "wpackagist-plugin/tablepress": "1.14",
     "wpackagist-plugin/wordfence": "7.10.3",
+    "wpackagist-plugin/wordpress-importer": "0.8.1",
     "wpackagist-theme/twentytwentythree": "1.2"
   }
 }

--- a/config/composer/composer.lock
+++ b/config/composer/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d5d2ac7e23095d14ea162d607e3d149e",
+    "content-hash": "5fd64e6320b030496e3bcb220631a006",
     "packages": [
         {
             "name": "composer/installers",
@@ -258,6 +258,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/wordfence/"
+        },
+        {
+            "name": "wpackagist-plugin/wordpress-importer",
+            "version": "0.8.1",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/wordpress-importer/",
+                "reference": "tags/0.8.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/wordpress-importer.0.8.1.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/wordpress-importer/"
         },
         {
             "name": "wpackagist-theme/twentytwentythree",

--- a/setup-wordpress.sh
+++ b/setup-wordpress.sh
@@ -16,6 +16,7 @@ akismet
 classic-editor
 redirection
 tablepress
+wordpress-importer
 '
 ACTIVATE_THEMES='
 vocabulary-theme


### PR DESCRIPTION
## Description
add WordPress Importer plugin
- WP-CLI import help:
  > Provides a command line interface to the WordPress Importer plugin, for performing data migrations.

## Technical details
JSON normalized with:
```shell
f=config/composer/composer.json; jq -SM '.' ${f} > new && mv new ${f}
```

## Tests
```shell
docker compose run --rm composer validate
```
```
[+] Creating 2/0
 ✔ Container cc-wordpress-db  Running                                          0.0s 
 ✔ Container cc-web           Running                                          0.0s 
./composer.json is valid, but with a few warnings
See https://getcomposer.org/doc/04-schema.md for details on the schema
# General warnings
- require.reyhoun/acf-menu-chooser : exact version constraints (1.1) should be avoided if the package follows semantic versioning
- require.wpackagist-plugin/advanced-custom-fields : exact version constraints (6.1.8) should be avoided if the package follows semantic versioning
- require.wpackagist-plugin/classic-editor : exact version constraints (1.6.3) should be avoided if the package follows semantic versioning
- require.wpackagist-plugin/redirection : exact version constraints (4.9.2) should be avoided if the package follows semantic versioning
- require.wpackagist-plugin/tablepress : exact version constraints (1.14) should be avoided if the package follows semantic versioning
- require.wpackagist-plugin/wordfence : exact version constraints (7.10.3) should be avoided if the package follows semantic versioning
- require.wpackagist-theme/twentytwentythree : exact version constraints (1.2) should be avoided if the package follows semantic versioning
```
(warnings contradict best practices 🤦🏻 )

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
