### PR TITLE
switch to type vcs for vocabulary-theme

### DIFF
--- a/config/composer/composer.json
+++ b/config/composer/composer.json
@@ -13,16 +13,9 @@
       "url": "https://wpackagist.org"
     },
     {
-      "package": {
-        "dist": {
-          "type": "zip",
-          "url": "https://github.com/creativecommons/vocabulary-theme/archive/refs/tags/v0.3.0.zip"
-        },
-        "name": "creativecommons/vocabulary-theme",
-        "type": "wordpress-theme",
-        "version": "0.3.0"
-      },
-      "type": "package"
+      "no-api": true,
+      "type": "vcs",
+      "url": "https://github.com/creativecommons/vocabulary-theme"
     },
     {
       "package": {

--- a/config/composer/composer.lock
+++ b/config/composer/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1ce734b5c06fbb87717b54ee4a9c73df",
+    "content-hash": "412e2616b0206f1c2f6b0f53074fb47f",
     "packages": [
         {
             "name": "composer/installers",
@@ -153,12 +153,20 @@
         },
         {
             "name": "creativecommons/vocabulary-theme",
-            "version": "0.3.0",
+            "version": "v0.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/creativecommons/vocabulary-theme",
+                "reference": "178d1611f6f17f1f4b531514dcfda0571e5ad534"
+            },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/creativecommons/vocabulary-theme/archive/refs/tags/v0.3.0.zip"
+                "url": "https://api.github.com/repos/creativecommons/vocabulary-theme/zipball/178d1611f6f17f1f4b531514dcfda0571e5ad534",
+                "reference": "178d1611f6f17f1f4b531514dcfda0571e5ad534",
+                "shasum": ""
             },
-            "type": "wordpress-theme"
+            "type": "wordpress-theme",
+            "time": "2023-08-11T20:41:08+00:00"
         },
         {
             "name": "reyhoun/acf-menu-chooser",


### PR DESCRIPTION
## Description
switch to type vcs for vocabulary-theme

## Technical details
```shell
docker compose run --rm composer update 2>/dev/null
```
```
Loading composer repositories with package information
Info from https://repo.packagist.org: #StandWithUkraine
Updating dependencies
Nothing to modify in lock file
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
  - Downloading creativecommons/vocabulary-theme (v0.3.0)
  - Upgrading creativecommons/vocabulary-theme (0.3.0 => v0.3.0): Extracting archive
Generating autoload files
1 package you are using is looking for funding.
Use the `composer fund` command to find out more!
No security vulnerability advisories found
```

JSON normalized with:
```shell
f=config/composer/composer.json; jq -SM '.' ${f} > new && mv new ${f}
```

## Tests
```shell
docker compose run --rm composer validate 2>/dev/null
```
```
./composer.json is valid, but with a few warnings
See https://getcomposer.org/doc/04-schema.md for details on the schema
# General warnings
- require.reyhoun/acf-menu-chooser : exact version constraints (1.1) should be avoided if the package follows semantic versioning
- require.wpackagist-plugin/advanced-custom-fields : exact version constraints (6.1.8) should be avoided if the package follows semantic versioning
- require.wpackagist-plugin/classic-editor : exact version constraints (1.6.3) should be avoided if the package follows semantic versioning
- require.wpackagist-plugin/redirection : exact version constraints (4.9.2) should be avoided if the package follows semantic versioning
- require.wpackagist-plugin/tablepress : exact version constraints (1.14) should be avoided if the package follows semantic versioning
- require.wpackagist-plugin/wordfence : exact version constraints (7.10.3) should be avoided if the package follows semantic versioning
- require.wpackagist-theme/twentytwentythree : exact version constraints (1.2) should be avoided if the package follows semantic versioning
```
(warnings contradict best practices 🤦🏻 )

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
