### PR TITLE
update output formatting

### DIFF
--- a/setup-wordpress.sh
+++ b/setup-wordpress.sh
@@ -26,16 +26,16 @@ trap '_es=${?};
 source .env
 
 # https://en.wikipedia.org/wiki/ANSI_escape_code
-E0="$(printf "\033[0m")"        # reset
-E1="$(printf "\033[1m")"        # bold
-E30="$(printf "\033[30m")"      # black foreground
-E31="$(printf "\033[31m")"      # red foreground
-E33="$(printf "\033[33m")"      # yellow foreground
-E36="$(printf "\033[36m")"      # cyan foreground
-E90="$(printf "\033[90m")"      # bright black (gray) foreground
-E97="$(printf "\033[97m")"      # bright white foreground
-E100="$(printf "\033[100m")"    # bright black (gray) background
-E107="$(printf "\033[107m")"    # bright white background
+E0="$(printf "\e[0m")"        # reset
+E1="$(printf "\e[1m")"        # bold
+E30="$(printf "\e[30m")"      # black foreground
+E31="$(printf "\e[31m")"      # red foreground
+E33="$(printf "\e[33m")"      # yellow foreground
+E46="$(printf "\e[46m")"      # cyan background
+E90="$(printf "\e[90m")"      # bright black (gray) foreground
+E97="$(printf "\e[97m")"      # bright white foreground
+E100="$(printf "\e[100m")"    # bright black (gray) background
+E107="$(printf "\e[107m")"    # bright white background
 OPT_DATE_FORMAT=Y-m-d
 OPT_TIME_FORMAT='H:i'
 OPT_DEFAULT_COMMENT_STATUS=closed
@@ -123,11 +123,6 @@ composer_install() {
 }
 
 
-container_print() {
-    printf "${E36}%19s${E0} %s\n" "${1}" "${2}"
-}
-
-
 database_check() {
     header 'Check database'
     wpcli db check --color \
@@ -175,7 +170,7 @@ environment_info() {
     # index-composer
     printf "${E1}%s${E0} - %s\n" \
         'index-composer' 'A Dependency Manager for PHP'
-    container_print 'Composer version' \
+    print_key_val 'Composer version' \
         "$(docker compose run --rm index-composer \
             --no-ansi --version 2>/dev/null | sed -e's/^Composer version //')"
     echo
@@ -185,7 +180,7 @@ environment_info() {
         'Web server (WordPress and static HTML components)'
     print_var WEB_WP_URL
     print_var WEB_WP_DIR
-    container_print 'WordPress version:' "$(wpcli core version)"
+    print_key_val 'WordPress version' "$(wpcli core version)"
     echo
 
     # index-wpcli
@@ -199,7 +194,7 @@ environment_info() {
         _val="$( echo "${_line#*:}" | xargs)"
         [[ -n "${_val}" ]] || continue
         [[ "${_key}" =~ ^WP-CLI ]] || continue
-        container_print "${_key}:" "${_val}"
+        print_key_val "${_key}" "${_val}"
     done
     echo
 }
@@ -254,8 +249,13 @@ no_op() {
 }
 
 
+print_key_val() {
+    printf "${E97}${E100}%22s${E0} %s\n" "${1}:" "${2}"
+}
+
+
 print_var() {
-    printf "${E36}%19s${E0} %s\n" "${1}:" "${!1}"
+    print_key_val "${1}" "${!1}"
 }
 
 


### PR DESCRIPTION
## Description
update output formatting
- change variable printing to use same color as table header
  - more muted and easier to read when value wraps across multiple lines
- improve ansi color code handling
- print key value info pairs using same printf command as variable printing

(mostly this work is to maintain parity with other script work)

<!--
## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->

<!--
## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

## Screenshots
### New
<img width="489" alt="Screenshot 2023-08-18 at 10 39 59" src="https://github.com/creativecommons/index-dev-env/assets/691322/b055d084-55d9-48d4-bb10-18d4b29e6435">

### Old
<img width="487" alt="Screenshot 2023-08-18 at 10 40 36" src="https://github.com/creativecommons/index-dev-env/assets/691322/cc04de8c-0173-401a-9f86-6d4a20b4f30c">


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
