### PR TITLE
keep index-wpcli docker service running

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,6 +95,10 @@ services:
       - ./cache:/var/www/html/cache:ro
 
   index-wpcli:
+    # continue running until shutdown (this allows docker compoes exec which is
+    # much faster than docker compoes run)
+    # Thank you: https://serverfault.com/a/1084975
+    command: sh -c 'trap "exit" TERM; while true; do sleep 1; done'
     container_name: index-wpcli
     depends_on:
       - index-wpdb

--- a/setup-wordpress.sh
+++ b/setup-wordpress.sh
@@ -168,6 +168,9 @@ environment_info() {
     print_var WEB_WP_URL
     print_var WEB_WP_DIR
     print_key_val 'WordPress version' "$(wpcli core version)"
+    print_key_val 'PHP version' \
+        "$(docker compose exec index-web php --version \
+            | awk '/^PHP/ {print $2}')"
     echo
 
     # index-wpcli
@@ -183,6 +186,8 @@ environment_info() {
         [[ "${_key}" =~ ^WP-CLI ]] || continue
         print_key_val "${_key}" "${_val}"
     done
+    print_key_val 'PHP version' \
+        "$(wpcli cli info | awk '/^PHP version/ {print $3}')"
     echo
 }
 
@@ -320,13 +325,13 @@ wordpress_status() {
 
 wpcli() {
     # Call WP-CLI with appropriate site arguments via Docker
-    docker compose run --rm \
+    docker compose exec \
         --env WP_ADMIN_USER="${WP_ADMIN_USER}" \
         --env WP_ADMIN_PASS="${WP_ADMIN_PASS}" \
         --env WP_ADMIN_EMAIL="${WP_ADMIN_EMAIL}" \
         index-wpcli \
             /usr/local/bin/wp --path="${WEB_WP_DIR}" --url="${WEB_WP_URL}" \
-            "${@}" 2>/dev/null
+            "${@}"
 }
 
 

--- a/setup-wordpress.sh
+++ b/setup-wordpress.sh
@@ -9,8 +9,8 @@
 #   The "2>/dev/null" below silences the messages from docker compose run.
 #   For example, the output like the following will not be visible:
 #       [+] Creating 2/0
-#        ✔ Container cc-wordpress-db  Running                             0.0s
-#        ✔ Container cc-web           Running                             0.0s
+#        ✔ Container index-wpdb  Running                                  0.0s
+#        ✔ Container index-web   Running                                  0.0s
 #
 set -o errexit
 set -o errtrace

--- a/wpcli.sh
+++ b/wpcli.sh
@@ -15,18 +15,7 @@ WEB_WP_DIR=/var/www/html
 WEB_WP_URL=http://localhost:8080
 
 # Call WP-CLI with appropriate site arguments via Docker
-#
-# docker compose run redirects the stderr of any invoked executables to
-# stdout. The only messages that will appear on stderr are issued by
-# docker compose run itself. This appears to be an undocumented "feature":
-# https://docs.docker.com/engine/reference/commandline/compose_run/
-#
-# The "2>/dev/null" below silences the messages from docker compose run.
-# For example, the output like the following will not be visible:
-#     [+] Creating 2/0
-#      ✔ Container cc-wordpress-db  Running                             0.0s
-#      ✔ Container cc-web           Running                             0.0s
-docker compose run --rm \
+docker compose exec \
     --env WP_ADMIN_USER="${WP_ADMIN_USER}" \
     --env WP_ADMIN_PASS="${WP_ADMIN_PASS}" \
     --env WP_ADMIN_EMAIL="${WP_ADMIN_EMAIL}" \
@@ -34,5 +23,4 @@ docker compose run --rm \
         /usr/local/bin/wp \
             --path="${WEB_WP_DIR}" \
             --url="${WEB_WP_URL}" \
-            "${@}" \
-    2>/dev/null
+            "${@}"


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
Fixes #[issue number] by @[issue author]

## Description
Keep index-wpcli docker service running

This allows `docker compose exec` instead of `docker compose run --rm`. With thousands of WP-CLI invocations during migration, this should result in **a significant time savings** (see benchmark below--migration script should benefit even more).

## Technical details
new (`exec`):
```shell
time ./setup-wordpress.sh &>/dev/null
```
```

real	0m10.057s
user	0m2.173s
sys	0m1.119s
```


old (`run --rm`):
```shell
time ./setup-wordpress.sh &>/dev/null
```
```

real	0m18.149s
user	0m1.983s
sys	0m1.094s
```

## References
- [The right way to keep docker container started when it used for periodic tasks - Server Fault](https://serverfault.com/a/1084975)

<!--
## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
