### PR TITLE
update WordPress Redirection plugin to 5.3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Also see [`.env.example`](.env.example).
 | [Advanced Custom Fields][adv-custom-fields]              | `6.1.8`  |
 | [Advanced Custom Fields: Menu Chooser][acf-menu-chooser] | `1.1.0`  |
 | [Classic Editor][classic-editor]                         | `1.6.3`  |
-| [Redirection][redirection]                               | `4.9.2`  |
+| [Redirection][redirection]                               | `5.3.10` |
 | [Tablepress][tablepress]                                 | `1.14`   |
 | [Wordfence][wordfence]                                   | `7.10.3` |
 | [WordPress Importer][wp-importer]                        | `0.8.1`  |

--- a/config/composer/composer.json
+++ b/config/composer/composer.json
@@ -35,7 +35,7 @@
     "reyhoun/acf-menu-chooser": "1.1",
     "wpackagist-plugin/advanced-custom-fields": "6.1.8",
     "wpackagist-plugin/classic-editor": "1.6.3",
-    "wpackagist-plugin/redirection": "4.9.2",
+    "wpackagist-plugin/redirection": "5.3.10",
     "wpackagist-plugin/tablepress": "1.14",
     "wpackagist-plugin/wordfence": "7.10.3",
     "wpackagist-plugin/wordpress-importer": "0.8.1",

--- a/config/composer/composer.lock
+++ b/config/composer/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c71f6b2c50c0010ae0ed757a68cd12b8",
+    "content-hash": "684ed1ae60375742c0d75e4759b0d753",
     "packages": [
         {
             "name": "composer/installers",
@@ -215,15 +215,15 @@
         },
         {
             "name": "wpackagist-plugin/redirection",
-            "version": "4.9.2",
+            "version": "5.3.10",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/redirection/",
-                "reference": "tags/4.9.2"
+                "reference": "tags/5.3.10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/redirection.4.9.2.zip"
+                "url": "https://downloads.wordpress.org/plugin/redirection.5.3.10.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"


### PR DESCRIPTION
## Description
update WordPress Redirection plugin to 5.3.10

## Technical details
The JSON export/import format seems fragile/version dependent, but the CSV format is very simple. The migration script is using the CSV export/import format.


## Tests
```
http -h 'https://staging:staging@stage.creativecommons.org/share-your-work/licensing-types-examples/'
```
```
HTTP/1.1 301 Moved Permanently
CF-Cache-Status: DYNAMIC
CF-RAY: 8095397408137ed1-LAX
Cache-Control: max-age=3600
Connection: keep-alive
Content-Type: text/html; charset=UTF-8
Date: Tue, 19 Sep 2023 22:21:55 GMT
Expires: Tue, 19 Sep 2023 23:21:55 GMT
Location: /about/cclicenses/
Server: cloudflare
Transfer-Encoding: chunked
X-Redirect-By: redirection
```

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
