### PR TITLE
update core plugins versions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # WordPress variables
-WP_VERSION=6.3
+WP_VERSION=6.3.1
 
 # Setup WordPress variables
 WP_ADMIN_EMAIL=

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ See [`config/web-sites-available/000-default.conf`][dev-webconfig].
 
 | Name      | Version |
 | --------- | ------- |
-| WordPress | `6.3`   |
+| WordPress | `6.3.1`   |
 
 Also see [`.env.example`](.env.example).
 

--- a/README.md
+++ b/README.md
@@ -165,23 +165,27 @@ Also see [`.env.example`](.env.example).
 
 | Name                                                     | Version  |
 | -------------------------------------------------------- | -------- |
-| [Advanced Custom Fields][adv-custom-fields]              | `6.1.8`  |
+| [Advanced Custom Fields][adv-custom-fields]              | `6.2.1`  |
 | [Advanced Custom Fields: Menu Chooser][acf-menu-chooser] | `1.1.0`  |
 | [Classic Editor][classic-editor]                         | `1.6.3`  |
+| [Monster Insights Google Analytics][monster-insights]    | `8.19`   |
 | [Redirection][redirection]                               | `5.3.10` |
-| [Tablepress][tablepress]                                 | `1.14`   |
-| [Wordfence][wordfence]                                   | `7.10.3` |
+| [Tablepress][tablepress]                                 | `2.1.7`  |
+| [Wordfence][wordfence]                                   | `7.10.4` |
 | [WordPress Importer][wp-importer]                        | `0.8.1`  |
+| [Yoast SEO][yoast-seo]                                   | `21.2`   |
 
 Also see [`config/composer/composer.json`](config/composer/composer.json).
 
 [adv-custom-fields]: https://wordpress.org/plugins/advanced-custom-fields/
 [acf-menu-chooser]: https://github.com/reyhoun/acf-menu-chooser
 [classic-editor]: https://wordpress.org/plugins/classic-editor/
+[monster-insights]: https://wordpress.org/plugins/google-analytics-for-wordpress/
 [redirection]: https://wordpress.org/plugins/redirection/
 [tablepress]: https://wordpress.org/plugins/tablepress/
 [wordfence]: https://wordpress.org/plugins/wordfence/
 [wp-importer]: https://wordpress.org/plugins/wordpress-importer/
+[yoast-seo]: https://wordpress.org/plugins/wordpress-seo/
 
 
 ### WordPress themes

--- a/config/composer/composer.json
+++ b/config/composer/composer.json
@@ -35,10 +35,12 @@
     "reyhoun/acf-menu-chooser": "1.1",
     "wpackagist-plugin/advanced-custom-fields": "6.1.8",
     "wpackagist-plugin/classic-editor": "1.6.3",
+    "wpackagist-plugin/google-analytics-for-wordpress": "8.19",
     "wpackagist-plugin/redirection": "5.3.10",
-    "wpackagist-plugin/tablepress": "1.14",
-    "wpackagist-plugin/wordfence": "7.10.3",
+    "wpackagist-plugin/tablepress": "2.1.7",
+    "wpackagist-plugin/wordfence": "7.10.4",
     "wpackagist-plugin/wordpress-importer": "0.8.1",
+    "wpackagist-plugin/wordpress-seo": "21.2",
     "wpackagist-theme/twentytwentythree": "1.2"
   }
 }

--- a/config/composer/composer.lock
+++ b/config/composer/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3295ea48c9f8f57c05a58ef1ea800e64",
+    "content-hash": "ff0e4ca0496cf64e878e81cab6b0a57d",
     "packages": [
         {
             "name": "composer/installers",
@@ -214,6 +214,24 @@
             "homepage": "https://wordpress.org/plugins/classic-editor/"
         },
         {
+            "name": "wpackagist-plugin/google-analytics-for-wordpress",
+            "version": "8.19",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/google-analytics-for-wordpress/",
+                "reference": "trunk"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/google-analytics-for-wordpress.zip?timestamp=1692805114"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/google-analytics-for-wordpress/"
+        },
+        {
             "name": "wpackagist-plugin/redirection",
             "version": "5.3.10",
             "source": {
@@ -233,15 +251,15 @@
         },
         {
             "name": "wpackagist-plugin/tablepress",
-            "version": "1.14",
+            "version": "2.1.7",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/tablepress/",
-                "reference": "tags/1.14"
+                "reference": "tags/2.1.7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/tablepress.1.14.zip"
+                "url": "https://downloads.wordpress.org/plugin/tablepress.2.1.7.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -251,15 +269,15 @@
         },
         {
             "name": "wpackagist-plugin/wordfence",
-            "version": "7.10.3",
+            "version": "7.10.4",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/wordfence/",
-                "reference": "tags/7.10.3"
+                "reference": "tags/7.10.4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wordfence.7.10.3.zip"
+                "url": "https://downloads.wordpress.org/plugin/wordfence.7.10.4.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -284,6 +302,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/wordpress-importer/"
+        },
+        {
+            "name": "wpackagist-plugin/wordpress-seo",
+            "version": "21.2",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/wordpress-seo/",
+                "reference": "tags/21.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/wordpress-seo.21.2.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/wordpress-seo/"
         },
         {
             "name": "wpackagist-theme/twentytwentythree",


### PR DESCRIPTION
## Description
* bump wordpress `core` to `v6.3.1`
  - change `.env.example` to match
* bump plugins versions
  - `advanced-custom-fields` : `6.1.8`
  - `google-analytics-for-wordpress` : `8.19`
  - `tablepress` : `2.1.7`
  - `wordfence` : `7.10.4`
* add new plugins
  - `google-analytics-for-wordpress` : `8.19`
  - `wordpress-seo` : `21.2`
* match versions in `README.md`

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
