### PR TITLE
exclude `/licences` from rewrite rule

### DIFF
--- a/config/web-sites-available/000-default.conf
+++ b/config/web-sites-available/000-default.conf
@@ -126,7 +126,7 @@ ServerName localhost:8080
         RewriteCond %{REQUEST_URI} !^/rdf
         RewriteCond %{REQUEST_URI} !^/publicdomain
         RewriteCond %{REQUEST_URI} !^/platform/toolkit
-        RewriteCond %{REQUEST_URI} !^/licenses
+        RewriteCond %{REQUEST_URI} !^/licen[cs]es
         RewriteCond %{REQUEST_URI} !^/faq
         RewriteCond %{REQUEST_URI} !^/choose
         RewriteCond %{REQUEST_URI} !^/cc-legal-tools


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
Fixes #[issue number] by @[issue author]

## Description
- exclude `/licences` from rewrite rule
- follows-up on:
  - #58

## Technical details
The rewrite rule that is modified only has `L|last` flag (not the `PT|passthrough` flag).

[L|last - RewriteRule Flags - Apache HTTP Server Version 2.5](https://httpd.apache.org/docs/trunk/rewrite/flags.html#flag_l) excerpt:
> The [L] flag causes [mod_rewrite](https://httpd.apache.org/docs/trunk/mod/mod_rewrite.html) to stop processing the rule set. In most contexts, this means that if the rule matches, no further rules will be processed. This corresponds to the `last` command in Perl, or the `break` command in C. Use this flag to indicate that the current rule should be applied immediately without considering further rules.

[PT|passthrough - RewriteRule Flags - Apache HTTP Server Version 2.5](https://httpd.apache.org/docs/trunk/rewrite/flags.html#flag_pt) excerpt:
> The target (or substitution string) in a [RewriteRule](https://httpd.apache.org/docs/trunk/mod/mod_rewrite.html#rewriterule) is assumed to be a file path, by default. The use of the [PT] flag causes it to be treated as a URI instead. That is to say, the use of the [PT] flag causes the result of the RewriteRule to be passed back through URL mapping, so that location-based mappings, such as [Alias](https://httpd.apache.org/docs/trunk/mod/mod_alias.html#alias), [Redirect](https://httpd.apache.org/docs/trunk/mod/mod_alias.html#redirect), or [ScriptAlias](https://httpd.apache.org/docs/trunk/mod/mod_alias.html#scriptalias), for example, might have a chance to take effect.
> 
> If, for example, you have an [Alias](https://httpd.apache.org/docs/trunk/mod/mod_alias.html#alias) for /icons, and have a [RewriteRule](https://httpd.apache.org/docs/trunk/mod/mod_rewrite.html#rewriterule) pointing there, you should use the [PT] flag to ensure that the [Alias](https://httpd.apache.org/docs/trunk/mod/mod_alias.html#alias) is evaluated.
> 
>     Alias "/icons" "/usr/local/apache/icons"
>     RewriteRule "/pics/(.+)\.jpg$" "/icons/$1.gif" [PT]
> 
> Omission of the [PT] flag in this case will cause the Alias to be ignored, resulting in a 'File not found' error being returned.
> 
> The `PT` flag implies the `L` flag: rewriting will be stopped in order to pass the request to the next phase of processing.
> 
> Note that the `PT` flag is implied in per-directory contexts such as [<Directory>](https://httpd.apache.org/docs/trunk/mod/core.html#directory) sections or in `.htaccess` files. The only way to circumvent that is to rewrite to -.

## Tests
```shell
http -h http://localhost:8080/licences
```
```
HTTP/1.1 301 Moved Permanently
Connection: Keep-Alive
Content-Length: 315
Content-Type: text/html; charset=iso-8859-1
Date: Tue, 28 Nov 2023 19:06:55 GMT
Keep-Alive: timeout=5, max=100
Location: http://localhost:8080/licenses
Server: Apache/2.4.56 (Debian)
```

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
