### PR TITLE
Apache2: Ensure plaintext files are served using UTF-8

### DIFF
--- a/config/web-sites-available/000-default.conf
+++ b/config/web-sites-available/000-default.conf
@@ -7,6 +7,8 @@ ServerName localhost:8080
     RewriteEngine On
 
     ###########################################################################
+    # Ensure plaintext files are served using UTF-8
+    AddCharset utf-8 .txt
     # Set conservative/secure defaults
     <Directory />
         AllowOverride None


### PR DESCRIPTION
## Description
Browsers aren't very good at determining the characterset of plaintext files and/or have bad default values (not UTF-8).

This PR updates Apache2 to set the default characterset to UTF-8 for plaintext files.

<!--
## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->

## Tests
```
http --response-charset=windows-1252 http://localhost:8080/licenses/by/4.0/legalcode.txt
```
```
http --response-charset=utf-8 http://localhost:8080/licenses/by/4.0/legalcode.txt
```

## Screenshots
### Old/Current
![Screenshot 2024-01-10 at 08-11-59 ](https://github.com/creativecommons/index-dev-env/assets/691322/a03cf997-d227-4907-9a4d-49c72a37bebc)
- `â€œLicensor.â€` (CP-1252 encoding)

### New/PR
![Screenshot 2024-01-10 at 08-13-30 ](https://github.com/creativecommons/index-dev-env/assets/691322/f6aac0a7-5095-4bfa-85ce-9a17b65f2275)
- `“Licensor.”` (UTF-8 encoding)

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
