### PR TITLE
add additional legacy redirects

### DIFF
--- a/config/web-sites-available/000-default.conf
+++ b/config/web-sites-available/000-default.conf
@@ -61,8 +61,10 @@ ServerName localhost:8080
         RewriteRule (.*/rdf$) $1 [T=application/rdf+xml]
     </Directory>
     Include /var/www/git/cc-legal-tools-data/config/language-redirects
-    RedirectPermanent  /licenses/mark/1.0  /publicdomain/mark/1.0
-    RedirectPermanent  /licences           /licenses
+    RedirectPermanent   /licenses/work-html-popup   /choose
+    RedirectPermanent   /licenses/publicdomain/     /publicdomain/
+    RedirectPermanent   /licenses/mark/1.0          /publicdomain/mark/1.0
+    RedirectPermanent   /licences                   /licenses
 
     ###########################################################################
     # Chooser

--- a/config/web-sites-available/000-default.conf
+++ b/config/web-sites-available/000-default.conf
@@ -123,6 +123,9 @@ ServerName localhost:8080
         # WP-API
         RewriteRule ^(/wp-json/.*)$ /index.php$1 [L]
 
+        # Legacy theme (hotlinked image that gives CC exposure)
+        RedirectPermanent /wp-content/themes/cc/images/cc.logo.white.svg https://ccstatic.org/cc2016www/images/cc.logo.white.svg
+
         # Permalinks (for dirs/files not found)
         # https://codex.wordpress.org/Using_Permalinks
         # Directory Conditions


### PR DESCRIPTION
## Fixes
(once replicated to production, will reduce 404s)

## Description
add additional legacy redirects

<!--
## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->

## Tests
- `/wp-content/themes/cc/images/cc.logo.white.svg`
  - Before:
    ```
    http -h http://localhost:8080/wp-content/themes/cc/images/cc.logo.white.svg
    ```
    ```
    HTTP/1.1 404 Not Found
    Cache-Control: no-cache, must-revalidate, max-age=0
    Connection: Keep-Alive
    Content-Type: text/html; charset=UTF-8
    Date: Mon, 22 Jan 2024 18:07:02 GMT
    Expires: Wed, 11 Jan 1984 05:00:00 GMT
    Keep-Alive: timeout=5, max=100
    Link: <http://localhost:8080/wp-json/>; rel="https://api.w.org/"
    Server: Apache/2.4.56 (Debian)
    Transfer-Encoding: chunked
    X-Powered-By: PHP/8.0.30
    ```
  - After:
    ```
    http -h http://localhost:8080/wp-content/themes/cc/images/cc.logo.white.svg
    ```
    ```
    HTTP/1.1 301 Moved Permanently
    Connection: Keep-Alive
    Content-Length: 340
    Content-Type: text/html; charset=iso-8859-1
    Date: Mon, 22 Jan 2024 18:07:45 GMT
    Keep-Alive: timeout=5, max=100
    Location: https://ccstatic.org/cc2016www/images/cc.logo.white.svg
    Server: Apache/2.4.56 (Debian)
    ```
- `/licenses/publicdomain/`
  - Before:
    ```
    http -h http://localhost:8080/licenses/publicdomain/
    ```
    ```
    HTTP/1.1 404 Not Found
    Connection: Keep-Alive
    Content-Length: 273
    Content-Type: text/html; charset=iso-8859-1
    Date: Mon, 22 Jan 2024 17:36:27 GMT
    Keep-Alive: timeout=5, max=100
    Server: Apache/2.4.56 (Debian)
    ```
  - After:
    ```
    http -h http://localhost:8080/licenses/publicdomain/
    ```
    ```
    HTTP/1.1 301 Moved Permanently
    Connection: Keep-Alive
    Content-Length: 320
    Content-Type: text/html; charset=iso-8859-1
    Date: Mon, 22 Jan 2024 17:36:53 GMT
    Keep-Alive: timeout=5, max=100
    Location: http://localhost:8080/publicdomain/
    Server: Apache/2.4.56 (Debian)
    ```
- `/licenses/work-html-popup`
  - Before: 
    ```
    http -h http://localhost:8080/licenses/work-html-popup
    ```
    ```
    HTTP/1.1 404 Not Found
    Connection: Keep-Alive
    Content-Length: 273
    Content-Type: text/html; charset=iso-8859-1
    Date: Mon, 22 Jan 2024 17:36:39 GMT
    Keep-Alive: timeout=5, max=100
    Server: Apache/2.4.56 (Debian)
    ```
    
  - After:
    ```
    http -h http://localhost:8080/licenses/work-html-popup
    ```
    ```
    HTTP/1.1 301 Moved Permanently
    Connection: Keep-Alive
    Content-Length: 313
    Content-Type: text/html; charset=iso-8859-1
    Date: Mon, 22 Jan 2024 17:37:34 GMT
    Keep-Alive: timeout=5, max=100
    Location: http://localhost:8080/choose
    Server: Apache/2.4.56 (Debian)
    ```

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
