### PR TITLE
Redirect chooser PDM (mark) to public wiki and reverse sort redirects

### DIFF
--- a/config/web-sites-available/000-default.conf
+++ b/config/web-sites-available/000-default.conf
@@ -95,9 +95,10 @@ ServerName localhost:8080
 #        # Deny access to PHP files (content should be only static files)
 #        RewriteRule .*\.php "-" [F,L]
 #    </Directory>
-    RedirectPermanent /choose/zero  /choose
+    RedirectTemp /choose/mark/  https://wiki.creativecommons.org/wiki/PDM_FAQ
+    RedirectTemp /choose        https://chooser-beta.creativecommons.org
     RedirectPermanent /chooser      /choose
-    RedirectTemp /choose https://chooser-beta.creativecommons.org
+    RedirectPermanent /choose/zero  /choose
 
     ###########################################################################
     # FAQ


### PR DESCRIPTION
## Mitigations
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'.  -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Mitigates creativecommons/chooser#531

## Description
- Redirect chooser PDM (`mark`) to public wiki
- Reverse sort redirects

## Technical details
Redirects should always be reverse sorted so that most specific redirects are first

## Tests
### Before PR
command:
```shell
http --all --follow --headers http://localhost:8080/choose/mark/
```
output:
```
HTTP/1.1 302 Found
Connection: Keep-Alive
Content-Length: 307
Content-Type: text/html; charset=iso-8859-1
Date: Wed, 05 Jun 2024 17:09:16 GMT
Keep-Alive: timeout=5, max=100
Location: https://chooser-beta.creativecommons.org/mark/
Server: Apache/2.4.59 (Debian)

HTTP/1.1 404 Not Found
Accept-Ranges: bytes
Access-Control-Allow-Origin: *
Age: 0
Connection: keep-alive
Content-Encoding: gzip
Content-Length: 5254
Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; img-src data:; connect-src 'self'
Content-Type: text/html; charset=utf-8
Date: Wed, 05 Jun 2024 17:09:16 GMT
ETag: W/"64d39a40-24a3"
Server: GitHub.com
Vary: Accept-Encoding
Via: 1.1 varnish
X-Cache: MISS
X-Cache-Hits: 0
X-Fastly-Request-ID: 16581c2620882be2adaf3b8cd4aead8878a1358e
X-GitHub-Request-Id: 794E:309351:1D19C60:1EAC36D:66609BBB
X-Served-By: cache-bur-kbur8200179-BUR
X-Timer: S1717607356.215911,VS0,VE94
x-proxy-cache: MISS
```

### After/With PR
1st command:
```
docker compose restart index-web
```
1st output:
```
[+] Restarting 1/1
 ✔ Container index-web  Started                                                0.2s 
```

2nd command:
```
http --all --follow --headers http://localhost:8080/choose/mark/
```
2nd output:
```
HTTP/1.1 302 Found
Connection: Keep-Alive
Content-Length: 306
Content-Type: text/html; charset=iso-8859-1
Date: Wed, 05 Jun 2024 17:11:13 GMT
Keep-Alive: timeout=5, max=100
Location: https://wiki.creativecommons.org/wiki/PDM_FAQ
Server: Apache/2.4.59 (Debian)

HTTP/1.1 200 OK
CF-Cache-Status: DYNAMIC
CF-RAY: 88f1c7d62b496a2d-LAX
Cache-Control: private, must-revalidate, max-age=0
Connection: keep-alive
Content-Encoding: gzip
Content-Language: en
Content-Type: text/html; charset=UTF-8
Date: Wed, 05 Jun 2024 17:11:14 GMT
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Last-Modified: Wed, 22 May 2024 08:29:07 GMT
Server: cloudflare
Transfer-Encoding: chunked
Vary: Accept-Encoding,Cookie
X-Content-Type-Options: nosniff
```

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
