### PR TITLE
add second PDM redirect

### DIFF
--- a/config/web-sites-available/000-default.conf
+++ b/config/web-sites-available/000-default.conf
@@ -99,6 +99,7 @@ ServerName localhost:8080
     RedirectTemp  /choose/zero          https://chooser-beta.creativecommons.org
     RedirectTemp  /choose/publicdomain  https://chooser-beta.creativecommons.org
     RedirectTemp  /choose/mark/  https://wiki.creativecommons.org/wiki/PDM_FAQ
+    RedirectTemp  /choose/mark   https://wiki.creativecommons.org/wiki/PDM_FAQ
     RedirectTemp  /choose               https://chooser-beta.creativecommons.org
 
     ###########################################################################


### PR DESCRIPTION
## Description
add second PDM redirect

(a second redirect is needed instead of replacing the existing redirect because `https://wiki.creativecommons.org/wiki/PDM_FAQ/` results in a 404)

<!--
## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->

## Tests
Command:
```shell
http --all --follow --headers http://localhost:8080/choose/mark/
```

### Before (failing)
Output:
```
HTTP/1.1 302 Found
Connection: Keep-Alive
Content-Length: 306
Content-Type: text/html; charset=iso-8859-1
Date: Wed, 10 Jul 2024 15:16:42 GMT
Keep-Alive: timeout=5, max=100
Location: https://chooser-beta.creativecommons.org/mark
Server: Apache/2.4.59 (Debian)

HTTP/1.1 404 Not Found
Accept-Ranges: bytes
Access-Control-Allow-Origin: *
Age: 0
Connection: keep-alive
Content-Encoding: gzip
Content-Length: 5254
Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; img-src data:; connect-src 'self'
Content-Type: text/html; charset=utf-8
Date: Wed, 10 Jul 2024 15:16:42 GMT
ETag: W/"64d39a40-24a3"
Server: GitHub.com
Vary: Accept-Encoding
Via: 1.1 varnish
X-Cache: MISS
X-Cache-Hits: 0
X-Fastly-Request-ID: cfb714ee39a3c38d24721c058180a2d4619de575
X-GitHub-Request-Id: E38A:3FB0FC:2AE5E7D:2C73EE2:668EA5DA
X-Served-By: cache-lax-kwhp1940046-LAX
X-Timer: S1720624603.895833,VS0,VE92
x-proxy-cache: MISS
```

### After (fixed)
Output:
```
HTTP/1.1 302 Found
Connection: Keep-Alive
Content-Length: 306
Content-Type: text/html; charset=iso-8859-1
Date: Wed, 10 Jul 2024 15:19:36 GMT
Keep-Alive: timeout=5, max=100
Location: https://wiki.creativecommons.org/wiki/PDM_FAQ
Server: Apache/2.4.59 (Debian)

HTTP/1.1 200 OK
CF-Cache-Status: DYNAMIC
CF-RAY: 8a118874cf257cb6-LAX
Cache-Control: private, must-revalidate, max-age=0
Connection: keep-alive
Content-Encoding: gzip
Content-Language: en
Content-Type: text/html; charset=UTF-8
Date: Wed, 10 Jul 2024 15:19:37 GMT
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Last-Modified: Wed, 22 May 2024 08:29:07 GMT
Server: cloudflare
Transfer-Encoding: chunked
Vary: Accept-Encoding,Cookie
X-Content-Type-Options: nosniff
```

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
