### PR TITLE
Enable content negotiation for RDF/XML

### DIFF
--- a/config/web-sites-available/000-default.conf
+++ b/config/web-sites-available/000-default.conf
@@ -36,7 +36,6 @@ ServerName localhost:8080
     ###########################################################################
     # CC Legal Tools
     # Directory Aliases
-    Alias /status           /var/www/git/cc-legal-tools-data/docs/status
     Alias /rdf              /var/www/git/cc-legal-tools-data/docs/rdf
     Alias /publicdomain     /var/www/git/cc-legal-tools-data/docs/publicdomain
     Alias /licenses         /var/www/git/cc-legal-tools-data/docs/licenses
@@ -47,7 +46,7 @@ ServerName localhost:8080
     Alias /ns           /var/www/git/cc-legal-tools-data/docs/rdf/ns.html
     # Ensure lowercase
     RewriteMap lowercase int:tolower
-    RewriteCond %{REQUEST_URI} ^/(licenses|publicdomain) [NC]
+    RewriteCond %{REQUEST_URI} ^/(licenses|publicdomain|rdf) [NC]
     RewriteCond %{REQUEST_URI} [A-Z]
     RewriteRule ^(.*)$ ${lowercase:$1} [R=301,L]
     <Directory /var/www/git/cc-legal-tools-data/docs>
@@ -57,6 +56,11 @@ ServerName localhost:8080
         Header set Access-Control-Allow-Origin "*"
         # Correct mimetype for .../rdf files
         RewriteRule (.*/rdf$) $1 [T=application/rdf+xml]
+        # Serve RDF/XML when requested, even if URL is for index (deed), deed,
+        # or legalcode
+        RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+        RewriteCond %{REQUEST_URI} (/(licenses|publicdomain)/[^/]+/.*)(/.*)
+        RewriteRule "(.*)(/|/deed.*|/index.*|/legalcode.*)$" "%1/rdf" [R=303]
         # Language redirects
         Include /var/www/git/cc-legal-tools-data/config/language-redirects
         # Also serve HTML files without .html extension


### PR DESCRIPTION
## Fixes
- Fixes #78 by @TimidRobot 

## Description
- Enable content negotiation for RDF/XML
- Remove unused `/status` alias
- Add `/rdf` to case fixing (ensure lowercase)

<!--
## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->

## Tests

- For additional documentation on commands, see #78

### No document (directory) URL

- Command
    ```shell
    rm -f saved_output; docker compose restart index-web; sleep 1; echo; http -pHhm -d -o saved_output -v http://localhost:8080/licenses/by-nc/4.0/ Accept:application/rdf+xml
    ```
- <details>
  <summary>Output <i>(click to expand/collapse)</i></summary>

    ```
    [+] Restarting 1/1
     ✔ Container index-web  Started                                                0.3s 
    
    GET /licenses/by-nc/4.0/ HTTP/1.1
    Accept: application/rdf+xml
    Accept-Encoding: identity
    Connection: keep-alive
    Host: localhost:8080
    User-Agent: HTTPie/3.2.3
    
    HTTP/1.1 303 See Other
    Connection: Keep-Alive
    Content-Length: 328
    Content-Type: text/html; charset=iso-8859-1
    Date: Wed, 25 Sep 2024 14:22:07 GMT
    Keep-Alive: timeout=5, max=100
    Location: http://localhost:8080/licenses/by-nc/4.0/rdf
    Server: Apache/2.4.59 (Debian)
    
    Elapsed time: 0.004184084s
    
    GET /licenses/by-nc/4.0/rdf HTTP/1.1
    Accept: application/rdf+xml
    Accept-Encoding: identity
    Connection: keep-alive
    Host: localhost:8080
    User-Agent: HTTPie/3.2.3
    
    HTTP/1.1 200 OK
    Accept-Ranges: bytes
    Access-Control-Allow-Origin: *
    Connection: Keep-Alive
    Content-Length: 11849
    Content-Type: application/rdf+xml
    Date: Wed, 25 Sep 2024 14:22:07 GMT
    ETag: "2e49-622c9e98c4784"
    Keep-Alive: timeout=5, max=99
    Last-Modified: Mon, 23 Sep 2024 14:07:42 GMT
    Server: Apache/2.4.59 (Debian)
    
    Elapsed time: 0.009172166s
    
    Downloading to saved_output
    Done. 11.8 kB in 00:0.05106 (232.1 kB/s
    ```

  </details>

- ✅ with `Accept:application/rdf+xml`, `saved_output` is RDF/XML
- ✅ without ~~`Accept:application/rdf+xml`~~, `saved_output` is HTML

### Deed URL

- Command
    ```shell
    rm -f saved_output; docker compose restart index-web; sleep 1; echo; http -pHhm -d -o saved_output -v http://localhost:8080/licenses/by-nc/4.0/deed Accept:application/rdf+xml
    ```
- <details>
  <summary>Output <i>(click to expand/collapse)</i></summary>

    ```
    [+] Restarting 1/1
     ✔ Container index-web  Started                                                0.2s 
    
    GET /licenses/by-nc/4.0/deed HTTP/1.1
    Accept: application/rdf+xml
    Accept-Encoding: identity
    Connection: keep-alive
    Host: localhost:8080
    User-Agent: HTTPie/3.2.3
    
    HTTP/1.1 303 See Other
    Connection: Keep-Alive
    Content-Length: 328
    Content-Type: text/html; charset=iso-8859-1
    Date: Wed, 25 Sep 2024 14:30:00 GMT
    Keep-Alive: timeout=5, max=100
    Location: http://localhost:8080/licenses/by-nc/4.0/rdf
    Server: Apache/2.4.59 (Debian)
    
    Elapsed time: 0.005735041s
    
    GET /licenses/by-nc/4.0/rdf HTTP/1.1
    Accept: application/rdf+xml
    Accept-Encoding: identity
    Connection: keep-alive
    Host: localhost:8080
    User-Agent: HTTPie/3.2.3
    
    HTTP/1.1 200 OK
    Accept-Ranges: bytes
    Access-Control-Allow-Origin: *
    Connection: Keep-Alive
    Content-Length: 11849
    Content-Type: application/rdf+xml
    Date: Wed, 25 Sep 2024 14:30:00 GMT
    ETag: "2e49-622c9e98c4784"
    Keep-Alive: timeout=5, max=99
    Last-Modified: Mon, 23 Sep 2024 14:07:42 GMT
    Server: Apache/2.4.59 (Debian)
    
    Elapsed time: 0.003239417s
    
    Downloading to saved_output
    Done. 11.8 kB in 00:0.03688 (321.3 kB/s)
    ```

  </details>

- ✅ with `Accept:application/rdf+xml`, `saved_output` is RDF/XML
- ✅ without ~~`Accept:application/rdf+xml`~~, `saved_output` is HTML

### Legal Code URL

- Command
    ```shell
    rm -f saved_output; docker compose restart index-web; sleep 1; echo; http -pHhm -d -o saved_output -v http://localhost:8080/licenses/by-nc/4.0/legalcode Accept:application/rdf+xml
    ```
- <details>
  <summary>Output <i>(click to expand/collapse)</i></summary>

    ```
    [+] Restarting 1/1
     ✔ Container index-web  Started                                                0.3s 
    
    GET /licenses/by-nc/4.0/legalcode HTTP/1.1
    Accept: application/rdf+xml
    Accept-Encoding: identity
    Connection: keep-alive
    Host: localhost:8080
    User-Agent: HTTPie/3.2.3
    
    HTTP/1.1 303 See Other
    Connection: Keep-Alive
    Content-Length: 328
    Content-Type: text/html; charset=iso-8859-1
    Date: Wed, 25 Sep 2024 14:33:27 GMT
    Keep-Alive: timeout=5, max=100
    Location: http://localhost:8080/licenses/by-nc/4.0/rdf
    Server: Apache/2.4.59 (Debian)
    
    Elapsed time: 0.005540417s
    
    GET /licenses/by-nc/4.0/rdf HTTP/1.1
    Accept: application/rdf+xml
    Accept-Encoding: identity
    Connection: keep-alive
    Host: localhost:8080
    User-Agent: HTTPie/3.2.3
    
    HTTP/1.1 200 OK
    Accept-Ranges: bytes
    Access-Control-Allow-Origin: *
    Connection: Keep-Alive
    Content-Length: 11849
    Content-Type: application/rdf+xml
    Date: Wed, 25 Sep 2024 14:33:27 GMT
    ETag: "2e49-622c9e98c4784"
    Keep-Alive: timeout=5, max=99
    Last-Modified: Mon, 23 Sep 2024 14:07:42 GMT
    Server: Apache/2.4.59 (Debian)
    
    Elapsed time: 0.004560208s
    
    Downloading to saved_output
    Done. 11.8 kB in 00:0.03376 (350.9 kB/s)
    ```

  </details>

- ✅ with `Accept:application/rdf+xml`, `saved_output` is RDF/XML
- ✅ without ~~`Accept:application/rdf+xml`~~, `saved_output` is HTML

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
