### PR TITLE
Update Apache2 rewrite RegEx more specific for non-WordPress components

### DIFF
--- a/config/web-sites-available/000-default.conf
+++ b/config/web-sites-available/000-default.conf
@@ -153,13 +153,13 @@ ServerName localhost:8080
         # https://codex.wordpress.org/Using_Permalinks
         # Directory Conditions
         RewriteCond %{REQUEST_FILENAME} !-d
-        RewriteCond %{REQUEST_URI} !^/rdf
-        RewriteCond %{REQUEST_URI} !^/publicdomain
-        RewriteCond %{REQUEST_URI} !^/platform/toolkit
-        RewriteCond %{REQUEST_URI} !^/licen[cs]es
-        RewriteCond %{REQUEST_URI} !^/faq
-        RewriteCond %{REQUEST_URI} !^/choose
-        RewriteCond %{REQUEST_URI} !^/cc-legal-tools
+        RewriteCond %{REQUEST_URI} !^/rdf(/|$)
+        RewriteCond %{REQUEST_URI} !^/publicdomain(/|$)
+        RewriteCond %{REQUEST_URI} !^/platform/toolkit(/|$)
+        RewriteCond %{REQUEST_URI} !^/licen[cs]es(/|$)
+        RewriteCond %{REQUEST_URI} !^/faq(/|$)
+        RewriteCond %{REQUEST_URI} !^/choose(/|$)
+        RewriteCond %{REQUEST_URI} !^/cc-legal-tools(/|$)
         # File Conditions
         RewriteCond %{REQUEST_FILENAME} !-f
         RewriteCond %{REQUEST_URI} !^/schema.rdf$


### PR DESCRIPTION
## Fixes
- Fixes #90 

## Description
Update Apache2 rewrite RegEx more specific for non-WordPress components

<!--
## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->

## Tests
### Prep
In local **dev** WordPress Admin:
1. Create and publish `faq-cert-program` page in WordPress
2. Create and publish `choose-our-campaign` page in WordPress
3. Create and publish `publicdomainday` page in WordPress

### FAQ redirect
- Description:
  >  - If a user navigates to /faq the rewrite/redirect SHOULD occur.
- Command:
    ```bash
    http --all --follow --headers 'http://localhost:8080/faq'
    ```
- Output (✅ redirect and non-WordPress 200 OK):
    ```
    HTTP/1.1 301 Moved Permanently
    Connection: Keep-Alive
    Content-Length: 311
    Content-Type: text/html; charset=iso-8859-1
    Date: Mon, 31 Mar 2025 06:07:54 GMT
    Keep-Alive: timeout=5, max=100
    Location: http://localhost:8080/faq/
    Server: Apache/2.4.59 (Debian)
    
    HTTP/1.1 200 OK
    Accept-Ranges: bytes
    Connection: Keep-Alive
    Content-Encoding: gzip
    Content-Type: text/html
    Date: Mon, 31 Mar 2025 06:07:54 GMT
    ETag: "38039-62907b0195ec6-gzip"
    Keep-Alive: timeout=5, max=99
    Last-Modified: Thu, 12 Dec 2024 00:20:56 GMT
    Server: Apache/2.4.59 (Debian)
    Transfer-Encoding: chunked
    Vary: Accept-Encoding
    ```

### FAQ link
- Description:
  >  - if a user navigates to /faq/thing the rewrite/redirect SHOULD occur.
- Command:
    ```bash
    http --all --follow --headers 'http://localhost:8080/faq/#for-licensors'
    ```
- Output (✅ non-WordPress 200 OK):
    ```
    HTTP/1.1 200 OK
    Accept-Ranges: bytes
    Connection: Keep-Alive
    Content-Encoding: gzip
    Content-Type: text/html
    Date: Mon, 31 Mar 2025 06:08:11 GMT
    ETag: "38039-62907b0195ec6-gzip"
    Keep-Alive: timeout=5, max=100
    Last-Modified: Thu, 12 Dec 2024 00:20:56 GMT
    Server: Apache/2.4.59 (Debian)
    Transfer-Encoding: chunked
    Vary: Accept-Encoding
    ```

### WordPress FAQ-other
- Description:
  >  - if a user navigates to /faq-item-here the rewrite/redirect should NOT occur.
- Command:
    ```bash
    http --all --follow --headers 'http://localhost:8080/faq-cert-program'
    ```
- Output (✅ WordPress redirect and 200 OK):
    ```
    HTTP/1.1 301 Moved Permanently
    Cache-Control: max-age=3600
    Connection: Keep-Alive
    Content-Length: 0
    Content-Type: text/html; charset=UTF-8
    Date: Mon, 31 Mar 2025 06:08:30 GMT
    Expires: Mon, 31 Mar 2025 07:08:30 GMT
    Keep-Alive: timeout=5, max=100
    Location: http://localhost:8080/faq-cert-program/
    Server: Apache/2.4.59 (Debian)
    X-Redirect-By: WordPress
    
    HTTP/1.1 200 OK
    Connection: Keep-Alive
    Content-Encoding: gzip
    Content-Length: 6474
    Content-Type: text/html; charset=UTF-8
    Date: Mon, 31 Mar 2025 06:08:30 GMT
    Keep-Alive: timeout=5, max=99
    Link: <http://localhost:8080/wp-json/>; rel="https://api.w.org/"
    Link: <http://localhost:8080/wp-json/wp/v2/pages/74943>; rel="alternate"; type="application/json"
    Link: <http://localhost:8080/?p=74943>; rel=shortlink
    Server: Apache/2.4.59 (Debian)
    Vary: Accept-Encoding
    ```

### WordPress choose-other
- Description:
  >  - if a user navigates to /choose-use-this-holiday-season the rewrite/redirect should NOT occur.
- Command:
    ```bash
    http --all --follow --headers 'http://localhost:8080/choose-our-campaign'
    ```
- Output (✅ WordPress redirect and 200 OK):
    ```
    HTTP/1.1 301 Moved Permanently
    Cache-Control: max-age=3600
    Connection: Keep-Alive
    Content-Length: 0
    Content-Type: text/html; charset=UTF-8
    Date: Mon, 31 Mar 2025 06:09:19 GMT
    Expires: Mon, 31 Mar 2025 07:09:19 GMT
    Keep-Alive: timeout=5, max=100
    Location: http://localhost:8080/choose-our-campaign/
    Server: Apache/2.4.59 (Debian)
    X-Redirect-By: WordPress
    
    HTTP/1.1 200 OK
    Connection: Keep-Alive
    Content-Encoding: gzip
    Content-Length: 6477
    Content-Type: text/html; charset=UTF-8
    Date: Mon, 31 Mar 2025 06:09:19 GMT
    Keep-Alive: timeout=5, max=99
    Link: <http://localhost:8080/wp-json/>; rel="https://api.w.org/"
    Link: <http://localhost:8080/wp-json/wp/v2/pages/74945>; rel="alternate"; type="application/json"
    Link: <http://localhost:8080/?p=74945>; rel=shortlink
    Server: Apache/2.4.59 (Debian)
    Vary: Accept-Encoding
    ```

### WordPress publicdomain-other
- Description:
  >  - if a user navigates to /publicdomainday the rewrite/redirect should NOT occur.
- Command:
    ```bash
    http --all --follow --headers 'http://localhost:8080/publicdomainday'
    ```
- Output (✅ WordPress redirect and 200 OK):
    ```
    HTTP/1.1 301 Moved Permanently
    Cache-Control: max-age=3600
    Connection: Keep-Alive
    Content-Length: 0
    Content-Type: text/html; charset=UTF-8
    Date: Mon, 31 Mar 2025 06:09:42 GMT
    Expires: Mon, 31 Mar 2025 07:09:42 GMT
    Keep-Alive: timeout=5, max=100
    Location: http://localhost:8080/publicdomainday/
    Server: Apache/2.4.59 (Debian)
    X-Redirect-By: WordPress
    
    HTTP/1.1 200 OK
    Connection: Keep-Alive
    Content-Encoding: gzip
    Content-Length: 6456
    Content-Type: text/html; charset=UTF-8
    Date: Mon, 31 Mar 2025 06:09:42 GMT
    Keep-Alive: timeout=5, max=99
    Link: <http://localhost:8080/wp-json/>; rel="https://api.w.org/"
    Link: <http://localhost:8080/wp-json/wp/v2/pages/74947>; rel="alternate"; type="application/json"
    Link: <http://localhost:8080/?p=74947>; rel=shortlink
    Server: Apache/2.4.59 (Debian)
    Vary: Accept-Encoding
    ```

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
