### PR TITLE
bump `vocabulary-theme` to `v1.13`

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Also see [`config/composer/composer.json`](config/composer/composer.json).
 
 | Name                                 | Version  |
 | ------------------------------------ | -------- |
-| [Vocabulary Theme][gh-vocab-theme]   | `1.12.1`    |
+| [Vocabulary Theme][gh-vocab-theme]   | `1.13`    |
 
 Also see [`config/composer/composer.json`](config/composer/composer.json).
 

--- a/config/composer/composer.json
+++ b/config/composer/composer.json
@@ -31,7 +31,7 @@
     }
   ],
   "require": {
-    "creativecommons/vocabulary-theme": "1.12.1",
+    "creativecommons/vocabulary-theme": "1.13",
     "reyhoun/acf-menu-chooser": "1.1",
     "wpackagist-plugin/advanced-custom-fields": "6.1.8",
     "wpackagist-plugin/classic-editor": "1.6.3",

--- a/config/composer/composer.lock
+++ b/config/composer/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c0d4f97b913fc18952254467f7ab552d",
+    "content-hash": "c139b0aa980267ad73dccbd583176ed7",
     "packages": [
         {
             "name": "composer/installers",
@@ -154,20 +154,20 @@
         },
         {
             "name": "creativecommons/vocabulary-theme",
-            "version": "v1.12.1",
+            "version": "v1.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/creativecommons/vocabulary-theme",
-                "reference": "d46dcd3af13583d92800614e8df8252677f6ee31"
+                "reference": "cafd97c28056f4b427b56f23c11571f0f33f89f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/creativecommons/vocabulary-theme/zipball/d46dcd3af13583d92800614e8df8252677f6ee31",
-                "reference": "d46dcd3af13583d92800614e8df8252677f6ee31",
+                "url": "https://api.github.com/repos/creativecommons/vocabulary-theme/zipball/cafd97c28056f4b427b56f23c11571f0f33f89f9",
+                "reference": "cafd97c28056f4b427b56f23c11571f0f33f89f9",
                 "shasum": ""
             },
             "type": "wordpress-theme",
-            "time": "2025-06-24T14:44:05+00:00"
+            "time": "2025-07-30T14:49:18+00:00"
         },
         {
             "name": "reyhoun/acf-menu-chooser",


### PR DESCRIPTION
## Description
* bump version in `composer.json` to `v1.13`
* update `README.md` to match

## Tests
**Note:** Be sure to first clear any localized caches before proceeding with tests.
 - [home-page](http://localhost:8080/) 
 - [sub-page](http://localhost:8080/about)
 - [team-index](http://localhost:8080/mission/team)
 - [search-index](http://localhost:8080/?s)
 - [archive-page](http://localhost:8080/blog/archive)
 - [blog-index](http://localhost:8080/blog)
 - [blog-post](http://localhost:8080/2025/03/03/from-strategy-to-action-focus-areas-for-2025/)
 - [faq](http://localhost:8080/faq)
 - [mp](http://localhost:8080/platform/toolkit/)
 - [licenses list](http://localhost:8080/licenses)
 - [license deed | EN](http://localhost:8080/licenses/by/4.0/)
 - [license legal code | EN](http://localhost:8080/licenses/by/4.0/legalcode.en)
 - [license deed | AR](http://localhost:8080/licenses/by/4.0/deed.ar)
 - [license legal code | AR](http://localhost:8080/licenses/by/4.0/legalcode.ar)

### `[list]` Shortcode Specific Tests

To test the new `[list]` shortcode, you will need to:
1. Create a page in the WP WYSIWYG
2. add the shortcode `[list]` to the content area
3. Save, publish
4. Navigate to page, see results. _(only if you have any published posts in your site)_

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
