### PR TITLE
Improve consistency and output clarity

### DIFF
--- a/setup-wordpress.sh
+++ b/setup-wordpress.sh
@@ -1,17 +1,4 @@
-#!/bin/bash
-#
-# Notes:
-# - docker compose run redirects the stderr of any invoked executables to
-#   stdout. The only messages that will appear on stderr are issued by docker
-#   compose run itself. This appears to be an undocumented "feature":
-#   https://docs.docker.com/engine/reference/commandline/compose_run/
-#
-#   The "2>/dev/null" below silences the messages from docker compose run.
-#   For example, the output like the following will not be visible:
-#       [+] Creating 2/0
-#        ✔ Container index-db  Running                                  0.0s
-#        ✔ Container index-web   Running                                  0.0s
-#
+#!/usr/bin/env bash
 set -o errexit
 set -o errtrace
 set -o nounset
@@ -32,10 +19,11 @@ E31="$(printf "\e[31m")"      # foreground: red
 E33="$(printf "\e[33m")"      # foreground: yellow
 E90="$(printf "\e[90m")"      # foreground: bright black (gray)
 E97="$(printf "\e[97m")"      # foreground: bright white
+E47="$(printf "\e[47m")"      # background: white
 E100="$(printf "\e[100m")"    # background: bright black (gray)
 E107="$(printf "\e[107m")"    # background: bright white
-OPT_DATE_FORMAT=Y-m-d
-OPT_DEFAULT_COMMENT_STATUS=closed
+OPT_DATE_FORMAT='Y-m-d'
+OPT_DEFAULT_COMMENT_STATUS='closed'
 OPT_PERMALINK_STRUCTURE='/%year%/%monthnum%/%day%/%postname%/'
 OPT_TIME_FORMAT='H:i'
 PLUGINS_ACTIVATE='
@@ -55,21 +43,22 @@ google-analytics-for-wordpress
 wordfence'
 PLUGINS_UNINSTALL='
 hello'
+SCRIPT_DIR="$(cd -P -- "${0%/*}" && pwd -P)"
 THEMES_ACTIVATE='
 vocabulary-theme'
 THEMES_REMOVE='
 twentytwentyone
 twentytwentytwo'
-WEB_WP_DIR=/var/www/index
-WEB_WP_URL=http://localhost:8080
-WP_USER="www-data"
+WEB_WP_DIR='/var/www/index'
+WEB_WP_URL='http://localhost:8080'
+WP_USER='www-data'
 
 #### FUNCTIONS ################################################################
 
 
 activate_plugins() {
     local _bold _plugin _reset
-    print_header 'Activate plugins'
+    print_header1 'Activate plugins'
     for _plugin in ${PLUGINS_ACTIVATE}
     do
         if wpcli --no-color --quiet plugin is-active "${_plugin}" &> /dev/null
@@ -88,7 +77,7 @@ activate_plugins() {
 
 activate_themes() {
     local _theme
-    print_header 'Activate themes'
+    print_header1 'Activate themes'
     for _theme in ${THEMES_ACTIVATE}
     do
         if wpcli --no-color --quiet theme is-active "${_theme}" &> /dev/null
@@ -129,7 +118,7 @@ check_user_permissions() {
 
 
 composer_install() {
-    print_header 'Composer install'
+    print_header1 'Composer install'
     docker compose run --rm index-web composer install --ansi 2>&1 \
         | sed \
             -e'/Container.*Running$/d' \
@@ -139,8 +128,56 @@ composer_install() {
 }
 
 
+container_info() {
+    local _msg
+    print_header1 'Container information'
+    # Ensure docker daemon is running
+    if [[ ! -S /var/run/docker.sock ]]
+    then
+        error_exit 'docker daemon is not running'
+    fi
+    # Ensure db service is running
+    if ! docker compose exec index-db true 2>/dev/null
+    then
+        error_exit 'docker service is not running: index-db'
+    fi
+    print_header2 'index-db container - Database server for WordPress'
+    print_key_val 'Debian version' \
+        "$(docker compose exec --no-tty 'index-db' \
+            cat /etc/debian_version)"
+    print_key_val 'MariaDB version' \
+        "$(docker compose exec --no-tty 'index-db' \
+            mariadb --version \
+                | awk -F',' '{print $1}')"
+    echo
+
+    # Ensure web service are running
+    if ! docker compose exec index-web true 2>/dev/null
+    then
+        error_exit "docker service is not running: index-web"
+    fi
+    _msg='index-web container - Web server (WordPress and static HTML'
+    _msg="${_msg} components)"
+    print_header2 "${_msg}"
+    print_key_val 'Debian version' \
+        "$(docker compose exec --no-tty 'index-web' \
+            cat /etc/debian_version)"
+    print_key_val 'PHP version' \
+        "$(docker compose exec --no-tty 'index-web' \
+            /usr/bin/php --version \
+                | awk '/^PHP/ {print $2}')"
+    print_key_val 'Composer version' \
+        "$(docker compose exec --no-tty 'index-web' \
+            composer --version 2>/dev/null \
+            | sed 's/Composer version \([^ ]*\).*/\1/')"
+    print_key_val 'WordPress version' "$(wpcli core version)"
+    print_key_val 'WP-CLI version' "$(wpcli cli version | cut -d' ' -f2)"
+    echo
+}
+
+
 database_check() {
-    print_header 'Check database'
+    print_header1 'Check database'
     wpcli db check --color \
         | sed -e'/^wordpress[.]wp_.*OK$/d'
     echo
@@ -148,7 +185,7 @@ database_check() {
 
 
 database_optimize() {
-    print_header 'Optimize database'
+    print_header1 'Optimize database'
     # Only show errors and summary
     wpcli db optimize --color \
         | sed \
@@ -160,7 +197,7 @@ database_optimize() {
 
 
 database_update() {
-    print_header 'Update database'
+    print_header1 'Update database'
     wpcli core update-db
     echo
 }
@@ -168,7 +205,7 @@ database_update() {
 
 deactivate_plugins() {
     local _bold _plugin _reset
-    print_header 'Deactivate plugins'
+    print_header1 'Deactivate plugins'
     for _plugin in ${PLUGINS_DEACTIVATE}
     do
         if wpcli --no-color --quiet plugin is-active "${_plugin}" &> /dev/null
@@ -182,44 +219,6 @@ deactivate_plugins() {
 }
 
 
-environment_info() {
-    local _key _val IFS
-    print_header 'Container information'
-
-    # index-db
-    printf "${E97}%s${E0} - %s\n" 'index-db' \
-        'Database server for WordPress'
-    print_key_val 'MariaDB version' \
-        "$(echo; docker compose exec index-db mariadb --version)"
-    echo
-
-    # index-web
-    printf "${E97}%s${E0} - %s\n" 'index-web' \
-        'Web server (WordPress and static HTML components)'
-    print_var WEB_WP_URL
-    print_var WEB_WP_DIR
-    print_key_val 'WordPress version' "$(wpcli core version)"
-    print_key_val 'PHP version' \
-        "$(docker compose exec index-web php --version \
-            | awk '/^PHP/ {print $2}')"
-    print_key_val 'Composer version' \
-        "$(docker compose run --rm index-web \
-            composer --version 2>/dev/null \
-            | sed 's/Composer version \([^ ]*\).*/\1/')"
-    IFS=$'\n'
-    for _line in $(wpcli --info | sort)
-    do
-        _key="${_line%%:*}"
-        # '| xargs' is used to trim whitespace
-        _val="$( echo "${_line#*:}" | xargs)"
-        [[ -n "${_val}" ]] || continue
-        [[ "${_key}" =~ ^WP-CLI ]] || continue
-        print_key_val "${_key}" "${_val}"
-    done
-    echo
-}
-
-
 error_exit() {
     # Echo error message and exit with error
     print_error "${*}"
@@ -227,41 +226,9 @@ error_exit() {
 }
 
 
-format_plugin_list() {
-    local _h _hm _hr
-    _h="${E97}${E100}"
-    # header match
-    _hm='(^name *)  (status *)  (update *)  (version)  (update_version)'
-    _hm="${_hm}  (auto_update)  (requires)  (requires_php)"
-    # header replace
-    _hr="${_h}\1${E0}  ${_h}\2${E0}  ${_h}\3${E0}  ${_h}\4${E0}  ${_h}\5${E0}"
-    _hr="${_hr}  ${_h}\6${E0}  ${_h}\7${E0}  ${_h}\8${E0}"
-    sed -u -E \
-        -e"s/${_hm}/${_hr}/" \
-        -e"s/(^.* inactive .*$)/${E90}\1${E0}/" \
-        -e"s/( active .*)( available )/\1${E33}\2${E0}/"
-}
-
-
-format_themes_list() {
-    local _h _hm _hr
-    _h="${E97}${E100}"
-    # header match
-    _hm='(^name *)  (status *)  (update *)  (version)  (update_version)'
-    _hm="${_hm}  (auto_update)"
-    # header replace
-    _hr="${_h}\1${E0}  ${_h}\2${E0}  ${_h}\3${E0}  ${_h}\4${E0}  ${_h}\5${E0}"
-    _hr="${_hr}  ${_h}\6${E0}"
-    sed -u -E \
-        -e"s/${_hm}/${_hr}/" \
-        -e"s/(^.* inactive .*$)/${E90}\1${E0}/" \
-        -e"s/( active .*)( available )/\1${E33}\2${E0}/"
-}
-
-
 install_wordpress() {
     local _err
-    print_header 'Install WordPress'
+    print_header1 'Install WordPress'
     if [[ -n "${WP_ADMIN_EMAIL}" ]] && [[ -n "${WP_ADMIN_EMAIL}" ]] \
         && [[ -n "${WP_ADMIN_EMAIL}" ]]
     then
@@ -289,22 +256,60 @@ install_wordpress() {
 }
 
 
+list_format1() {
+    # Normalize output and column widths
+    sed -u \
+        -e's/^name,/name                             ,/' \
+        -e's/,update,/,update     ,/' \
+        -e's/,update_version,/,update_ver,/' \
+        -e's/,none,/,-,/g' -e's/,,/,-,/g' -e's/,$/,-/' \
+        | column -s',' -t
+}
+
+
+list_format2() {
+    # Colorize column headers
+    local _h _hm _hr
+    _h="${E97}${E100}"
+    # header match
+    _hm='(^name *)  (update *)  (version)  (update_ver)  (auto_update)'
+    # header replace
+    _hr="${_h}\1${E0}  ${_h}\2${E0}  ${_h}\3${E0}  ${_h}\4${E0}  ${_h}\5${E0}"
+    sed -u -E -e"s/${_hm}/${_hr}/"
+}
+
+
+list_format3() {
+    # highlight updates available
+    sed -u -E -e"s/ (available) / ${E33}\1${E0} /"
+}
+
+
 list_plugins() {
-    print_header 'List plugins'
-    wpcli plugin list --format=csv \
-        | sed -e's/,none,/,-,/g' -e's/,,/,-,/g' -e's/,$/,-/' \
-        | column -s',' -t \
-        | format_plugin_list
+    local _fields
+    print_header1 'List plugins'
+    _fields='name,update,version,update_version,auto_update'
+    print_header2 'Active plugins'
+    wpcli plugin list --fields="${_fields}" --format=csv --status=active \
+        | list_format1 | list_format2 | list_format3
+    echo
+    print_header2 'Inactive plugins'
+    wpcli plugin list --fields="${_fields}" --format=csv --status=inactive \
+        | list_format1 | list_format2 | list_format3
     echo
 }
 
 
 list_themes() {
-    print_header 'List themes'
-    wpcli theme list --format=csv \
-        | sed -e's/,none,/,-,/g' -e's/,,/,-,/g' -e's/,$/,-/' \
-        | column -s',' -t \
-        | format_themes_list
+    print_header1 'List themes'
+    _fields='name,update,version,update_version,auto_update'
+    print_header2 'Active themes'
+    wpcli theme list --fields="${_fields}" --format=csv --status=active \
+        | list_format1 | list_format2 | list_format3
+    echo
+    print_header2 'Inactive themes'
+    wpcli theme list --fields="${_fields}" --format=csv --status=inactive \
+        | list_format1 | list_format2
     echo
 }
 
@@ -325,9 +330,15 @@ print_key_val() {
 }
 
 
-print_header() {
-    # Print 80 character wide black on white heading with time
-    printf "${E30}${E107}# %-70s$(date '+%T') ${E0}\n" "${@}"
+print_header1() {
+    # Print 80 character wide black on bright white heading with time
+    printf "${E30}${E107}# %-69s$(date '+%T') ${E0}\n" "${@}"
+}
+
+
+print_header2() {
+    # Print 80 character wide black on white heading
+    printf "${E30}${E47} %-78s ${E0}\n" "${@}"
 }
 
 
@@ -338,7 +349,7 @@ print_var() {
 
 remove_themes() {
     local _theme
-    print_header 'Remove extraneous themes'
+    print_header1 'Remove extraneous themes'
     for _theme in ${THEMES_REMOVE}
     do
         if ! wpcli --no-color --quiet theme is-installed "${_theme}" \
@@ -355,7 +366,7 @@ remove_themes() {
 
 uninstall_plugins() {
     local _bold _plugin _reset
-    print_header 'Uninstall plugins'
+    print_header1 'Uninstall plugins'
     for _plugin in ${PLUGINS_UNINSTALL}
     do
         if wpcli --no-color --quiet plugin is-installed "${_plugin}" \
@@ -373,7 +384,7 @@ uninstall_plugins() {
 update_options() {
     local _date_format _default_comment_status _noop _permalink_structure \
         _time_format
-    print_header 'Update options'
+    print_header1 'Update options'
 
     _date_format=$(wpcli option get date_format)
     if [[ "${OPT_DATE_FORMAT}" != "${_date_format}" ]]
@@ -385,8 +396,10 @@ update_options() {
     fi
 
     _default_comment_status=$(wpcli option get default_comment_status)
-    if [[ "${OPT_DEFAULT_COMMENT_STATUS}" != "${_default_comment_status}" ]]
+    if [[ "${OPT_DEFAULT_COMMENT_STATUS}" != "${_default_comment_status}" ]] \
+       && [[ -n "${_default_comment_status}" ]]
     then
+        echo "_default_comment_status: '${_default_comment_status}'"
         echo "Update default_comment_status: ${OPT_DEFAULT_COMMENT_STATUS}"
         wpcli option update default_comment_status \
             "${OPT_DEFAULT_COMMENT_STATUS}"
@@ -419,7 +432,7 @@ update_options() {
 
 
 wordpress_status() {
-    print_header 'Show maintenance mode status to expose any PHP Warnings'
+    print_header1 'Show maintenance mode status to expose any PHP Warnings'
     wpcli_loud maintenance-mode status
     echo
 }
@@ -428,7 +441,7 @@ wordpress_status() {
 wpcli() {
     # Call WP-CLI with appropriate site arguments via Docker and silence
     # warnings
-    docker compose exec -T --user "$WP_USER" \
+    docker compose exec --no-tty --user "$WP_USER" \
         --env WP_ADMIN_USER="${WP_ADMIN_USER}" \
         --env WP_ADMIN_PASS="${WP_ADMIN_PASS}" \
         --env WP_ADMIN_EMAIL="${WP_ADMIN_EMAIL}" \
@@ -439,8 +452,9 @@ wpcli() {
 
 
 wpcli_loud() {
-    # Call WP-CLI with appropriate site arguments via Docker
-    docker compose exec -T --user "$WP_USER" \
+    # Call WP-CLI with appropriate site arguments via Docker and colorize
+    # warnings
+    docker compose exec --no-tty --user "$WP_USER" \
         --env WP_ADMIN_USER="${WP_ADMIN_USER}" \
         --env WP_ADMIN_PASS="${WP_ADMIN_PASS}" \
         --env WP_ADMIN_EMAIL="${WP_ADMIN_EMAIL}" \
@@ -455,9 +469,10 @@ wpcli_loud() {
 
 #### MAIN #####################################################################
 
+cd "${SCRIPT_DIR}"
 check_requirements
 check_user_permissions
-environment_info
+container_info
 composer_install
 install_wordpress
 update_options

--- a/staff_migrate.sh
+++ b/staff_migrate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Notes:
 # - This script can only be run by Creative Commons (CC) staff--it requires
@@ -15,24 +15,29 @@ trap '_es=${?};
     printf " exited with a status of ${_es}\n";
     exit ${_es}' ERR
 
-DOCKER_WP_DIR=/var/www/index
-DOCKER_WP_URL=http://localhost:8080
+DOCKER_WP_DIR='/var/www/index'
+DOCKER_WP_URL='http://localhost:8080'
 # https://en.wikipedia.org/wiki/ANSI_escape_code
 E0="$(printf "\e[0m")"        # reset
 E1="$(printf "\e[1m")"        # bold
-E30="$(printf "\e[30m")"      # black foreground
-E31="$(printf "\e[31m")"      # red foreground
-E33="$(printf "\e[33m")"      # yellow foreground
-E43="$(printf "\e[43m")"      # yellow background
-E90="$(printf "\e[90m")"      # bright black (gray) foreground
-E92="$(printf "\e[92m")"      # bright green foreground
-E97="$(printf "\e[97m")"      # bright white foreground
-E100="$(printf "\e[100m")"    # bright black (gray) background
-E107="$(printf "\e[107m")"    # bright white background
-PROD_SERVER=index__prod
-PROD_UPLOADS_DIR=/var/www/index/wp-content/uploads
-PROD_WP_DIR=/var/www/index/wp
-PROD_WP_HOST=creativecommons.org
+E30="$(printf "\e[30m")"      # foreground: black
+E31="$(printf "\e[31m")"      # foreground: red
+E33="$(printf "\e[33m")"      # foreground: yellow
+E90="$(printf "\e[90m")"      # foreground: bright black (gray)
+E92="$(printf "\e[92m")"      # foreground: bright green
+E93="$(printf "\e[93m")"      # foreground: bright yellow
+E97="$(printf "\e[97m")"      # foreground: bright white
+E43="$(printf "\e[43m")"      # background: yellow
+E47="$(printf "\e[47m")"      # background: white
+E100="$(printf "\e[100m")"    # background: bright black (gray)
+E107="$(printf "\e[107m")"    # background: bright white
+NOTICE_STAFF="\
+⚠️ This script's pull command can only be run by Creative Commons (CC) team
+   members--it requires shell access to the legacy production server."
+PROD_SERVER='index__prod'
+PROD_UPLOADS_DIR='/var/www/index/wp-content/uploads'
+PROD_WP_DIR='/var/www/index/wp'
+PROD_WP_HOST='creativecommons.org'
 PROD_WP_URL="https://${PROD_WP_HOST}"
 declare -i RSYNC_PROT_VER_MIN=31
 # NOTE: wordfence does not play nice with Docker. Enabling it results in WP-CLI
@@ -40,9 +45,9 @@ declare -i RSYNC_PROT_VER_MIN=31
 #       instead of 0.8 seconds)
 PLUGINS_DEACTIVATE='
 google-analytics-for-wordpress
-wordfence
-'
+wordfence'
 SCRIPT_NAME="${0##*/}"
+
 # The configure_environment() function sets the following global variables:
 CACHE_SQL=''
 CACHE_DIR=''
@@ -50,14 +55,18 @@ CACHE_UPLOADS_DIR=''
 DOCKER_SQL=''
 DOCKER_WP_UPLOADS_DIR=''
 DOCKER_WP_UPLOADS_TEMP_DIR=''
+SCRIPT_DIR="$(cd -P -- "${0%/*}" && pwd -P)"
 SCRIPT_ENV=''
-SERVER_DOCROOT=''
-SERVER_POD=''
+# Linux server unimplemented
+#SERVER_DOCROOT=''
+#SERVER_POD=''
 SERVER_WP_DIR=''
 SERVER_WP_UPLOADS_DIR=''
 SERVER_WP_URL=''
+
 # The parse_command() function sets the following global variables:
 COMMAND=''
+
 # The rsync_version() function sets the following global variables:
 declare -i RSYNC_PROT_VER=0
 
@@ -107,7 +116,7 @@ danger_confirm() {
 
 deactivate_plugins() {
     local _bold _plugin _reset
-    header 'Deactivate plugins'
+    print_header1 'Deactivate plugins'
     for _plugin in ${PLUGINS_DEACTIVATE}
     do
         if wpcli --no-color --quiet plugin is-active "${_plugin}" &> /dev/null
@@ -123,7 +132,7 @@ deactivate_plugins() {
 
 delete_wordpress_uploads() {
     local _count
-    header 'Delete WordPress uploads'
+    print_header1 'Delete WordPress uploads'
     if [[ "${SCRIPT_ENV}" == 'docker' ]]
     then
         print_var DOCKER_WP_UPLOADS_DIR
@@ -149,15 +158,9 @@ error_exit() {
 }
 
 
-header() {
-    # Print 80 character wide black on white heading
-    printf "${E30}${E107} %-71s$(date '+%T') ${E0}\n" "${@}"
-}
-
-
 import_database() {
     local _sql
-    header 'Import database'
+    print_header1 'Import database'
     if [[ "${SCRIPT_ENV}" == 'docker' ]]
     then
         print_var DOCKER_SQL
@@ -174,7 +177,7 @@ import_database() {
 
 
 import_uploads() {
-    header 'Import uploads'
+    print_header1 'Import uploads'
     print_var CACHE_UPLOADS_DIR
     if [[ "${SCRIPT_ENV}" == 'docker' ]]
     then
@@ -209,7 +212,7 @@ no_op() {
 
 
 optimize_tables() {
-    header 'Optimize WordPress database tables'
+    print_header1 'Optimize WordPress database tables'
     wpcli db optimize --color \
         | sed -e'/Table does not support optimize/d' -e'/^status   : OK/d'
     echo
@@ -236,7 +239,7 @@ parse_command() {
 
 post_import_db_update_site_url() {
     local _new_url
-    header 'Post-import: Database update: Site URL'
+    print_header1 'Post-import: Database update: Site URL'
     print_var PROD_WP_URL
     if [[ "${SCRIPT_ENV}" == 'docker' ]]
     then
@@ -274,7 +277,19 @@ post_import_db_update_site_url() {
 }
 
 print_key_val() {
-    printf "${E97}${E100}%22s${E0} %s\n" "${1}:" "${2}"
+    printf "${E97}${E100}%24s${E0} %s\n" "${1}:" "${2}"
+}
+
+
+print_header1() {
+    # Print 80 character wide black on bright white heading
+    printf "${E30}${E107}# %-69s$(date '+%T') ${E0}\n" "${@}"
+}
+
+
+print_header2() {
+    # Print 80 character wide black on white heading
+    printf "${E30}${E47} %-78s ${E0}\n" "${@}"
 }
 
 
@@ -284,7 +299,7 @@ print_var() {
 
 
 pull_database() {
-    header 'Pull WordPress database'
+    print_header1 'Pull WordPress database'
     print_var PROD_SERVER
     print_var PROD_WP_DIR
     print_var CACHE_SQL
@@ -301,7 +316,7 @@ pull_database() {
 
 
 pull_uploads() {
-    header 'Pull WordPress uploads files from legacy production server'
+    print_header1 'Pull WordPress uploads files from legacy production server'
     print_var PROD_SERVER
     print_var PROD_UPLOADS_DIR
     print_var CACHE_DIR
@@ -326,7 +341,8 @@ pull_uploads() {
 
 
 rsync_version() {
-    local _rsync_version="$(rsync --version 2>&1 \
+    local _rsync_version
+    _rsync_version="$(rsync --version 2>&1 \
         | awk '/version/ {print $3", "$4" "$5" "$6}')"
     RSYNC_PROT_VER=${_rsync_version##* }
     print_key_val 'rsync version' "${_rsync_version}"
@@ -339,38 +355,13 @@ script_setup() {
     # linux server
     case $(uname) in
         Darwin)
-            header "Setup environment: local docker development"
+            print_header1 'Setup environment: local docker development'
+            CACHE_DIR=./cache
+            DOCKER_SQL="${DOCKER_WP_DIR}/cache/${PROD_WP_HOST}_export.sql"
+            DOCKER_WP_UPLOADS_DIR="${DOCKER_WP_DIR}/wp-content/uploads"
+            _var="${DOCKER_WP_DIR}/wp-content/uploads.temp"
+            DOCKER_WP_UPLOADS_TEMP_DIR="${_var}"
             SCRIPT_ENV=docker
-            print_var COMMAND
-            print_var SCRIPT_ENV
-            print_key_val "$(sw_vers --productName) version" \
-                "$(sw_vers --productVersion)"
-            rsync_version
-
-            # Ensure docker daemon is running
-            if [[ ! -S /var/run/docker.sock ]]
-            then
-                error_exit 'docker daemon is not running'
-            fi
-            # Ensure services are running
-            for _service in index-web index-db
-            do
-                if ! docker compose exec "${_service}" true 2>/dev/null
-                then
-                    error_exit "docker ${_service} service is not running"
-                fi
-            done
-            print_key_val 'Docker version' \
-                "$(docker --version | sed -e's/^Docker *version *//')"
-            print_key_val 'WordPress PHP version' \
-                "$(docker compose exec index-web php --version \
-                    | awk '/^PHP/ {print $2}')"
-            print_key_val 'WordPress version' "$(wpcli core version)"
-            print_key_val 'WP-CLI PHP version' \
-                "$(wpcli cli info | awk '/^PHP version/ {print $3}')"
-            print_key_val 'WP-CLI version' \
-                "$(wpcli cli version | cut -d' ' -f2)"
-            echo
 
             # Check execution environment
             if [[ "${PWD##*/}" != 'index-dev-env' ]]
@@ -381,7 +372,17 @@ script_setup() {
                 _err="${_err} 'index-dev-env')"
                 error_exit "${_err}"
             fi
+            mkdir -p "${CACHE_DIR}"
 
+            print_var COMMAND
+            print_var SCRIPT_ENV
+            echo
+
+            print_header2 'localhost'
+            print_key_val "$(sw_vers --productName) version" \
+                "$(sw_vers --productVersion)"
+
+            rsync_version
             # Check rsync version
             if (( RSYNC_PROT_VER < 31 ))
             then
@@ -391,18 +392,12 @@ script_setup() {
                 _err="${_err} new terminal to see new the rsync)"
                 error_exit "${_err}"
             fi
+            echo
 
-            CACHE_DIR=./cache
-            mkdir -p "${CACHE_DIR}"
-
-
-            DOCKER_WP_UPLOADS_DIR="${DOCKER_WP_DIR}/wp-content/uploads"
-            _var="${DOCKER_WP_DIR}/wp-content/uploads.temp"
-            DOCKER_WP_UPLOADS_TEMP_DIR="${_var}"
-            DOCKER_SQL="${DOCKER_WP_DIR}/cache/${PROD_WP_HOST}_export.sql"
+            verify_docker_services
             ;;
         Linux)
-            header "Setup environment: linux server"
+            print_header1 'Setup environment: linux server'
             #######################
             no_op 'unimplemented' #
             exit ##################
@@ -455,13 +450,12 @@ script_setup() {
     esac
     CACHE_UPLOADS_DIR="${CACHE_DIR}/uploads"
     CACHE_SQL="${CACHE_DIR}/${PROD_WP_HOST}_export.sql"
-    test_wordpress_installed
     staff_only_notice
 }
 
 
 show_help() {
-    header 'Usage'
+    print_header1 'Usage'
     echo "${SCRIPT_NAME} COMMAND"
     echo
     bold 'Commands'
@@ -481,9 +475,7 @@ show_help() {
 
 
 staff_only_notice() {
-    echo -n 'This script can only be run by Creative Commons (CC) staff--it'
-    echo ' requires shell'
-    echo 'access to the production server'
+    echo "${E93}${NOTICE_STAFF}${E0}"
     echo
 }
 
@@ -505,7 +497,7 @@ sudo_auth() {
 
 
 test_ssh_to_prod() {
-    header 'Test SSH connection to production server'
+    print_header1 'Test SSH connection to production server'
     print_var PROD_SERVER
     if ! ssh "${PROD_SERVER}" true
     then
@@ -525,18 +517,70 @@ test_wordpress_installed() {
 }
 
 
+verify_docker_services() {
+    local _msg
+    # Ensure docker daemon is running
+    if [[ ! -S /var/run/docker.sock ]]
+    then
+        error_exit 'docker daemon is not running'
+    fi
+    # Ensure db service is running
+    if ! docker compose exec index-db true 2>/dev/null
+    then
+        error_exit 'docker service is not running: index-db'
+    fi
+    print_header2 'index-db container - Database server for WordPress'
+    print_key_val 'Debian version' \
+        "$(docker compose exec --no-tty 'index-db' \
+            cat /etc/debian_version)"
+    print_key_val 'MariaDB version' \
+        "$(docker compose exec --no-tty 'index-db' \
+            mariadb --version \
+                | awk -F',' '{print $1}')"
+    echo
+
+    # Ensure web service are running
+    if ! docker compose exec index-web true 2>/dev/null
+    then
+        error_exit "docker service is not running: index-web"
+    fi
+    _msg='index-web container - Web server (WordPress and static HTML'
+    _msg="${_msg} components)"
+    print_header2 "${_msg}"
+    print_key_val 'Debian version' \
+        "$(docker compose exec --no-tty 'index-web' \
+            cat /etc/debian_version)"
+    print_key_val 'PHP version' \
+        "$(docker compose exec --no-tty 'index-web' \
+            /usr/bin/php --version \
+                | awk '/^PHP/ {print $2}')"
+    test_wordpress_installed
+    print_key_val 'WordPress version' "$(wpcli core version)"
+    print_key_val 'WP-CLI version' "$(wpcli cli version | cut -d' ' -f2)"
+    echo
+}
+
+
+wordpress_status() {
+    print_header1 'Show maintenance mode status to expose any PHP Warnings'
+    wpcli_loud maintenance-mode status
+    echo
+}
+
+
 wpcli() {
     case "${SCRIPT_ENV}" in
         'docker')
-        # Call WP-CLI with appropriate site arguments via Docker
-            docker compose exec index-web \
+            # Call WP-CLI with appropriate site arguments via Docker and
+            # silence warings
+            docker compose exec --no-tty index-web \
                 /usr/local/bin/wp \
                     --path="${DOCKER_WP_DIR}" \
                     --url="${DOCKER_WP_URL}" \
-                    "${@}"
+                    "${@}" 2> >(sed -e'/^PHP Warning:/d' -e'/^Warning:/d')
             ;;
         'server')
-        # Call WP-CLI with appropriate site arguments
+            # Call WP-CLI with appropriate site arguments
             /usr/local/bin/wp \
                 --path="${SERVER_WP_DIR}" \
                 --url="${SERVER_WP_URL}" \
@@ -546,8 +590,23 @@ wpcli() {
 }
 
 
+wpcli_loud() {
+    # Call WP-CLI with appropriate site arguments via Docker and colorize
+    # warnings
+    docker compose exec --no-tty index-web \
+            /usr/local/bin/wp \
+                --path="${DOCKER_WP_DIR}" \
+                --url="${DOCKER_WP_URL}" \
+                "${@}" 2> >(
+                    sed -e"s/PHP Warning:/${E33}PHP Warning:${E0}/" \
+                        -e"s/Warning:/${E33}Warning:${E0}/"
+                )
+}
+
+
 #### MAIN #####################################################################
 
+cd "${SCRIPT_DIR}"
 parse_command "${@:-}"
 case "${COMMAND}" in
     # the following are sorted by order of operations then lexicographically
@@ -570,5 +629,6 @@ case "${COMMAND}" in
         deactivate_plugins
         post_import_db_update_site_url
         optimize_tables
+        wordpress_status
         ;;
 esac


### PR DESCRIPTION
<!-- ⚠️ Pull requests (PRs) that don't follow this template will be discarded. -->
## Description
Improve consistency and output clarity
- Conclude changes began in #111
  - Fix table formatting (list plugins and list themes)
  - Consistent Docker container/service information across both scripts
  - Minor updates to improve consistency across both scripts

<!--
## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->

## Tests
`setup-wordpress.sh` checked with [`shellcheck`](https://www.shellcheck.net/)

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] I have read and understood the Developer Certificate of Origin (DCO), below, which covers the contents of this pull request (PR).
- [x] My pull request doesn't include code or content generated with AI (also see [Avoiding generative AI development tools — Creative Commons Open Source][no-ai]).
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated unit tests and/or test scripts for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[no-ai]: https://opensource.creativecommons.org/blog/entries/2025-12-01-avoiding-gen-ai-tools/
[best_practices]: https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
