### PR TITLE
Improve CC Legal Tools URI handling and add test script

### DIFF
--- a/config/web-sites-available/000-default.conf
+++ b/config/web-sites-available/000-default.conf
@@ -74,31 +74,22 @@ ServerName localhost:8080
         RewriteRule .*\.php$ "-" [F,L]
     </Directory>
     # Legacy/compatibilty redirects
-    RedirectPermanent   /licenses/work-html-popup       /choose
-    RedirectPermanent   /licences                       /licenses
+    RedirectPermanent   /license                /licenses
+    RedirectPermanent   /licences               /licenses
+    RedirectPermanent   /licence                /licenses
     # Redirect legacy public domain URLs
-    RedirectPermanent   /licenses/publicdomain/         /publicdomain/
-    RedirectPermanent   /licenses/mark/1.0              /publicdomain/mark/1.0
+    RedirectPermanent   /licenses/publicdomain/ /publicdomain/certification/1.0/us/deed.en
+    RedirectPermanent   /licenses/mark/1.0      /publicdomain/mark/1.0
     # Licenses 1.0 has reverse ordered components
-    RedirectPermanent   /licenses/nc-nd/1.0             /licenses/nd-nc/1.0
-    RedirectPermanent   /licenses/by-nc-nd/1.0          /licenses/by-nd-nc/1.0
+    RedirectPermanent   /licenses/nc-nd/1.0     /licenses/nd-nc/1.0
+    RedirectPermanent   /licenses/by-nc-nd/1.0  /licenses/by-nd-nc/1.0
     # Licenses 2.1 only includes ports
     RedirectMatch  301  /licenses/([^/]+)/2.1/(lega.*)  /licenses/$1/2.0/$2
     RedirectMatch  301  /licenses/([^/]+)/2.1/(deed.*)  /licenses/$1/2.0/$2
 
     ###########################################################################
     # Chooser
-#    Alias /choose /var/www/git/chooser/docs
-#    <Directory /var/www/git/chooser/docs>
-#        # Disable .htaccess (for security and performance)
-#        AllowOverride None
-#        # Redirect .../index.php to .../
-#        RewriteCond %{REQUEST_FILENAME} "index\.php$" [NC]
-#        RewriteCond %{REQUEST_FILENAME} !-f
-#        RewriteRule (.*/)index\.php$ $1 [L,NC,R=301]
-#        # Deny access to PHP files (content should be only static files)
-#        RewriteRule .*\.php "-" [F,L]
-#    </Directory>
+    RedirectPermanent   /licenses/work-html-popup       /choose
     RedirectTemp  /choose/mark/  https://wiki.creativecommons.org/wiki/PDM_FAQ
     RedirectTemp  /choose/mark   https://wiki.creativecommons.org/wiki/PDM_FAQ
 

--- a/config/web-sites-available/000-default.conf
+++ b/config/web-sites-available/000-default.conf
@@ -64,7 +64,7 @@ ServerName localhost:8080
         # Language redirects
         Include /var/www/git/cc-legal-tools-data/config/language-redirects
         # Also serve HTML files without .html extension
-        RewriteCond %{REQUEST_FILENAME}.html -f
+        RewriteCond %{LA-F:REQUEST_FILENAME}.html -f
         RewriteRule !.*\.html$ %{REQUEST_FILENAME}.html [L]
         # Redirect .../index.php to .../
         RewriteCond %{REQUEST_FILENAME} "index\.php$" [NC]

--- a/test_legal_tool_urls.sh
+++ b/test_legal_tool_urls.sh
@@ -170,6 +170,16 @@ ISSUE1433='
 /licenses/list.en/invalid/
 '
 
+# Found via:
+# ./wpcli.sh db query 'SELECT post_status, post_name, guid FROM wp_posts WHERE guid LIKE "http://localhost:8080/license%";'
+POTENTIAL_WP_COLLISIONS='
+/license-status/upcoming/2007/08/hong-kong/
+/license-status/upcoming/2007/08/thailand/
+'
+# Present, but not currently found in production
+# /license-status/upcoming/weblog/2009/11/20/weblog/19275
+# /license-status/upcoming/weblog/2009/11/20/weblog/19275
+
 #### FUNCTIONS ################################################################
 
 
@@ -269,4 +279,5 @@ test1_urls 'Issue 444 - all URLs' "${ISSUE444_FULL}"
 #test1_urls 'Issue 444 - selected URLs' "${ISSUE444_PART}"
 test1_urls 'Issue 236' "${ISSUE236}"
 test1_urls 'Compatibility' "${COMPATIBILITY}"
+test1_urls 'Potential WordPress collisions' "${POTENTIAL_WP_COLLISIONS}"
 test2_urls 'Issue 1433 (path after path)' "${ISSUE1433}"

--- a/test_legal_tool_urls.sh
+++ b/test_legal_tool_urls.sh
@@ -155,11 +155,14 @@ ISSUE444_PART='
 '
 
 COMPATIBILITY='
-/licences/
 /licenses/publicdomain/
-/licenses/mark/1.0/
 /licenses/nc-nd/1.0/
+/licenses/mark/1.0/
 /licenses/by-nc-nd/1.0/
+/license/
+/license
+/licences
+/licence
 '
 
 ISSUE1433='

--- a/test_legal_tool_urls.sh
+++ b/test_legal_tool_urls.sh
@@ -1,0 +1,269 @@
+#!/bin/bash
+set -o errexit
+set -o errtrace
+set -o nounset
+
+# https://en.wikipedia.org/wiki/ANSI_escape_code
+E0="$(printf     "\e[0m")"    # reset
+E30="$(printf "\e[30m")"      # black foreground
+E31="$(printf   "\e[31m")"    # red foreground
+E32="$(printf   "\e[32m")"    # green foreground
+E90="$(printf   "\e[90m")"    # bright black foreground
+E92="$(printf   "\e[92m")"    # bright green foreground
+E107="$(printf "\e[107m")"    # bright white background
+
+TARGET_HOST="${1:-http://localhost:8080}"
+
+ENSURE_LOWERCASE='
+/LiCeNsEs/By/4.0/DeEd.En
+/lIcEnSeS/bY/2.0/uK/
+'
+
+ALT_LANG_CODES='
+/licenses/by/3.0/es/legalcode.es-es
+/licenses/by/3.0/es/legalcode.oci
+/licenses/by/3.0/rs/legalcode.sr-cyrl
+/licenses/by/3.0/rs/legalcode.sr-latin
+/licenses/by/4.0/deed.zh
+/licenses/by/4.0/deed.zh_cn
+/licenses/by/4.0/deed.zh_tw
+'
+
+ISSUE236='
+/licenses/by-nc-nd/1.0/deed.INVALID
+/licenses/by-nd-nc/1.0/deed.INVALID
+/licenses/sampling/1.0/br/deed.apy
+/licenses/sampling+/1.0/deed.INVALID
+/licenses/by-nc-sa/2.0/deed.INVALID
+/licenses/by-nc/2.0/be/deed.wa
+/licenses/by-nd/2.1/deed.INVALID
+/licenses/by-sa/2.1/jp/deed.ryn
+/licenses/by/2.5/deed.INVALID
+/licenses/by/2.5/ar/deed.gn
+/licenses/by/3.0/deed.INVALID
+/licenses/by/3.0/am/deed.hy
+/licenses/by/3.0/es/deed.ast
+/licenses/by/4.0/deed.INVALID
+/licenses/by/4.0/deed.mi
+'
+
+# sorted with: sort -t'/' -V -k6 -k7 -k5
+ISSUE444_FULL='
+/licenses/by-nc-sa/1.0/il/
+/licenses/by-nc/1.0/il/
+/licenses/by-nd-nc/1.0/il/
+/licenses/by-nd/1.0/il/
+/licenses/by-sa/1.0/il/
+/licenses/by/1.0/il/
+/licenses/by-nc-nd/2.0/uk/
+/licenses/by-nc-sa/2.0/uk/
+/licenses/by-nc/2.0/uk/
+/licenses/by-nd/2.0/uk/
+/licenses/by-sa/2.0/uk/
+/licenses/by/2.0/uk/
+/licenses/by-nc-nd/2.0/za/
+/licenses/by-nc-sa/2.0/za/
+/licenses/by-nc/2.0/za/
+/licenses/by-nd/2.0/za/
+/licenses/by-sa/2.0/za/
+/licenses/by/2.0/za/
+/licenses/by-nc-nd/2.5/il/
+/licenses/by-nc-sa/2.5/il/
+/licenses/by-nc/2.5/il/
+/licenses/by-nd/2.5/il/
+/licenses/by-sa/2.5/il/
+/licenses/by/2.5/il/
+/licenses/by-nc-nd/2.5/in/
+/licenses/by-nc-sa/2.5/in/
+/licenses/by-nc/2.5/in/
+/licenses/by-nd/2.5/in/
+/licenses/by-sa/2.5/in/
+/licenses/by/2.5/in/
+/licenses/by-nc-nd/2.5/mk/
+/licenses/by-nc-sa/2.5/mk/
+/licenses/by-nc/2.5/mk/
+/licenses/by-nd/2.5/mk/
+/licenses/by-sa/2.5/mk/
+/licenses/by/2.5/mk/
+/licenses/by-nc-nd/2.5/scotland/
+/licenses/by-nc-sa/2.5/scotland/
+/licenses/by-nc/2.5/scotland/
+/licenses/by-nd/2.5/scotland/
+/licenses/by-sa/2.5/scotland/
+/licenses/by/2.5/scotland/
+/licenses/by-nc-nd/2.5/za/
+/licenses/by-nc-sa/2.5/za/
+/licenses/by-nc/2.5/za/
+/licenses/by-nd/2.5/za/
+/licenses/by-sa/2.5/za/
+/licenses/by/2.5/za/
+/licenses/by-nc-nd/3.0/am/
+/licenses/by-nc-sa/3.0/am/
+/licenses/by-nc/3.0/am/
+/licenses/by-nd/3.0/am/
+/licenses/by-sa/3.0/am/
+/licenses/by/3.0/am/
+/licenses/by-nc-nd/3.0/ge/
+/licenses/by-nc-sa/3.0/ge/
+/licenses/by-nc/3.0/ge/
+/licenses/by-nd/3.0/ge/
+/licenses/by-sa/3.0/ge/
+/licenses/by/3.0/ge/
+/licenses/by-nc-nd/3.0/hk/
+/licenses/by-nc-sa/3.0/hk/
+/licenses/by-nc/3.0/hk/
+/licenses/by-nd/3.0/hk/
+/licenses/by-sa/3.0/hk/
+/licenses/by/3.0/hk/
+/licenses/by-nc-nd/3.0/ie/
+/licenses/by-nc-sa/3.0/ie/
+/licenses/by-nc/3.0/ie/
+/licenses/by-nd/3.0/ie/
+/licenses/by-sa/3.0/ie/
+/licenses/by/3.0/ie/
+/licenses/by-nc-nd/3.0/sg/
+/licenses/by-nc-sa/3.0/sg/
+/licenses/by-nc/3.0/sg/
+/licenses/by-nd/3.0/sg/
+/licenses/by-sa/3.0/sg/
+/licenses/by/3.0/sg/
+/licenses/by-nc-nd/3.0/th/
+/licenses/by-nc-sa/3.0/th/
+/licenses/by-nc/3.0/th/
+/licenses/by-nd/3.0/th/
+/licenses/by-sa/3.0/th/
+/licenses/by/3.0/th/
+/licenses/by-nc-nd/3.0/vn/
+/licenses/by-nc-sa/3.0/vn/
+/licenses/by-nc/3.0/vn/
+/licenses/by-nd/3.0/vn/
+/licenses/by-sa/3.0/vn/
+/licenses/by/3.0/vn/
+/licenses/by-nc-nd/3.0/za/
+/licenses/by-nc-sa/3.0/za/
+/licenses/by-nc/3.0/za/
+/licenses/by-nd/3.0/za/
+/licenses/by-sa/3.0/za/
+/licenses/by/3.0/za/
+'
+
+ISSUE444_PART='
+/licenses/by-nc-sa/1.0/il/
+/licenses/by-nc-nd/2.0/uk/
+/licenses/by-nc-nd/2.5/mk/
+/licenses/by/3.0/am/
+'
+
+COMPATIBILITY='
+/licences/
+/licenses/publicdomain/
+/licenses/mark/1.0/
+/licenses/nc-nd/1.0/
+/licenses/by-nc-nd/1.0/
+'
+
+ISSUE1433='
+/licenses/list.it/by-nc/2.0/it/by-nc-sa/2.5/dk/sa/2.0/jp/by/4.0/legalcode.sk
+/licenses/list.en/invalid/
+'
+
+#### FUNCTIONS ################################################################
+
+
+header() {
+    # Print 80 character wide black on white heading with time
+    printf "${E30}${E107}# %-69s$(date '+%T') ${E0}\n" "${@}"
+}
+
+
+test1_urls() {
+    local _location _result _path _paths _url
+    _header="${1}"
+    _paths="${2}"
+    header "${_header}"
+    for _path in ${_paths}
+    do
+        _url="${TARGET_HOST}${_path}"
+        _result=$(http --headers --pretty none "${_url}?")
+        _code=$(echo "${_result}" | awk '/^HTTP/ {print $2}')
+        case ${_code} in
+            200) printf "${E92}";;
+            301) printf "${E32}";;
+            310) printf "${E32}";;
+              *) printf "${E31}";;
+        esac
+        printf "%-11s  %s${E0}\n" "HTTP/1.1 ${_code}" "${_url}"
+        if [[ "${_result}" =~ 301 ]]
+        then
+            _result=$(http --all --follow --headers --pretty none "${_url}")
+            _location=$(echo "${_result}" \
+                | awk '/^Location:/ {print $2}' \
+                | tail -n1)
+            _code=$(echo "${_result}" \
+                | awk '/^HTTP/ {print $2}' \
+                | tail -n1)
+            case ${_code} in
+                200) printf "${E92}";;
+                301) printf "${E32}";;
+                310) printf "${E32}";;
+                  *) printf "${E31}";;
+            esac
+            printf "%-11s  %s${E0}\n" ">>>>>>>> ${_code}" "${_location}"
+        fi
+    done
+    echo
+}
+
+
+test2_urls() {
+    local _location _result _path _paths _url
+    _header="${1}"
+    _paths="${2}"
+    header "${_header}"
+    for _path in ${_paths}
+    do
+        _url="${TARGET_HOST}${_path}"
+        _result=$(http --headers --pretty none "${_url}?")
+        _code=$(echo "${_result}" | awk '/^HTTP/ {print $2}')
+        case ${_code} in
+            404) printf "${E92}";;
+            301) printf "${E32}";;
+            310) printf "${E32}";;
+              *) printf "${E31}";;
+        esac
+        printf "%-11s  %s${E0}\n" "HTTP/1.1 ${_code}" "${_url}"
+        if [[ "${_result}" =~ 301 ]]
+        then
+            _result=$(http --all --follow --headers --pretty none "${_url}")
+            _location=$(echo "${_result}" \
+                | awk '/^Location:/ {print $2}' \
+                | tail -n1)
+            _code=$(echo "${_result}" \
+                | awk '/^HTTP/ {print $2}' \
+                | tail -n1)
+            case ${_code} in
+                200) printf "${E92}";;
+                301) printf "${E32}";;
+                310) printf "${E32}";;
+                  *) printf "${E31}";;
+            esac
+            printf "%-11s  %s${E0}\n" ">>>>>>>> ${_code}" "${_location}"
+        fi
+    done
+    echo
+}
+
+
+if [[ "${TARGET_HOST}" == 'http://localhost:8080' ]]
+then
+    docker compose restart index-web
+fi
+
+
+test1_urls 'Ensure lowercase' "${ENSURE_LOWERCASE}"
+test1_urls 'Alternate language codes' "${ALT_LANG_CODES}"
+test1_urls 'Issue 444 - all URLs' "${ISSUE444_FULL}"
+#test1_urls 'Issue 444 - selected URLs' "${ISSUE444_PART}"
+test1_urls 'Issue 236' "${ISSUE236}"
+test1_urls 'Compatibility' "${COMPATIBILITY}"
+test2_urls 'Issue 1433 (path after path)' "${ISSUE1433}"


### PR DESCRIPTION
<!-- ⚠️ Pull requests (PRs) that don't follow this template will be discarded. -->
## Related
- creativecommons/tech-support/issues/1433 (private repository)
- creativecommons/creativecommons.org/issues/1431

## Description
Improve CC Legal Tools URI handling and add test script
- Add `test_legal_tool_urls.sh` script
- Update Apache config
  - Update pretty URLS (Also serve HTML files without .html extensio) to use internal (filename-based) sub-request to determine final value of REQUEST_FILENAME
  - Clean-up and organize Chooser configuration
  - Add redirects for common typos

## Technical details
- https://httpd.apache.org/docs/current/mod/mod_rewrite.html#LA-U

## Tests
(added script completes successfully)

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] I have read and understood the Developer Certificate of Origin (DCO), below, which covers the contents of this pull request (PR).
- [x] My pull request doesn't include code or content generated with AI (also see [Avoiding generative AI development tools — Creative Commons Open Source][no-ai]).
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated unit tests and/or test scripts for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[no-ai]: https://opensource.creativecommons.org/blog/entries/2025-12-01-avoiding-gen-ai-tools/
[best_practices]: https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
