### PR TITLE
Add Plausible proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,16 +58,19 @@ EXPOSE 80
 
 
 # Enable Apache modules
-RUN a2enmod headers
-RUN a2enmod php8.2
-RUN a2enmod rewrite
+RUN a2enmod headers \
+    && a2enmod php8.2 \
+    && a2enmod proxy \
+    && a2enmod proxy_http \
+    && a2enmod rewrite \
+    && a2enmod ssl
 
 # Configure PHP
 COPY config/90-local.ini /etc/php/8.2/apache2/conf.d/
 
 # Install Composer
 # https://getcomposer.org/doc/00-intro.md#installation-linux-unix-macos
-RUN curl -sS https://getcomposer.org/installer \
+RUN curl --silent --show-error https://getcomposer.org/installer \
     | php -- --install-dir=/usr/local/bin --filename=composer
 
 # Create compose directory for www-data
@@ -77,9 +80,9 @@ RUN chown -R www-data:www-data /var/www/.composer
 
 # Install WordPress CLI (WP-CLI)
 # https://wp-cli.org/#installing
-RUN curl -L \
+RUN curl --silent --show-error --location \
     https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
-    -o wp-cli.phar \
+    --output wp-cli.phar \
     && chmod +x wp-cli.phar \
     && mv wp-cli.phar /usr/local/bin/wp
 
@@ -102,9 +105,9 @@ RUN wp core download --version=$WP_VERSION
 # Add WordPress basic configuration
 # 1) Download wp-config-docker.php for use as wp-config.php. Friendly view at:
 # https://github.com/docker-library/wordpress/blob/master/latest/php8.2/apache/wp-config-docker.php
-RUN curl -L \
+RUN curl --silent --show-error --location \
     https://raw.githubusercontent.com/docker-library/wordpress/master/latest/php8.2/apache/wp-config-docker.php \
-    -o /var/www/index/wp-config.php
+    --output /var/www/index/wp-config.php
 
 
 # 2) Use awk to replace all instances of "put your unique phrase here" with a

--- a/config/web-sites-available/000-default.conf
+++ b/config/web-sites-available/000-default.conf
@@ -9,13 +9,13 @@ ServerName localhost:8080
     RewriteEngine On
     SSLProxyEngine On
 
+    ###########################################################################
     # Privacy-friendly analytics by Plausible
     # (The Plausible script automatically disables itself on localhost.)
     <Location /p/script.js>
         ProxyPass https://plausible.io/js/pa-WRMaH3QHcCo_0RYbTsBgi.js
         ProxyPassReverse https://plausible.io/js/pa-WRMaH3QHcCo_0RYbTsBgi.js
     </Location>
-
     <Location /p/api/event>
         ProxyPass https://plausible.io/api/event
         ProxyPassReverse https://plausible.io/api/event

--- a/config/web-sites-available/000-default.conf
+++ b/config/web-sites-available/000-default.conf
@@ -4,7 +4,22 @@ ServerName localhost:8080
     ErrorLog ${APACHE_LOG_DIR}/error.log
     CustomLog ${APACHE_LOG_DIR}/access.log combined
 
+    ProxyPreserveHost Off
+    ProxyRequests Off
     RewriteEngine On
+    SSLProxyEngine On
+
+    # Privacy-friendly analytics by Plausible
+    # (The Plausible script automatically disables itself on localhost.)
+    <Location /p/script.js>
+        ProxyPass https://plausible.io/js/pa-WRMaH3QHcCo_0RYbTsBgi.js
+        ProxyPassReverse https://plausible.io/js/pa-WRMaH3QHcCo_0RYbTsBgi.js
+    </Location>
+
+    <Location /p/api/event>
+        ProxyPass https://plausible.io/api/event
+        ProxyPassReverse https://plausible.io/api/event
+    </Location>
 
     ###########################################################################
     # Ensure plaintext files are served using UTF-8


### PR DESCRIPTION
<!-- ⚠️ Pull requests (PRs) that don't follow this template will be discarded. -->
## Related
- creativecommons/tech-support/issues/1421 (private repository)

## Description
Add Plausible proxy
- (The Plausible script automatically disables itself on localhost. This is to verify the configuration prior to deployment in production.)

## Technical details
- [Proxying Plausible through Apache HTTP Server | Plausible docs](https://plausible.io/docs/proxy/guides/apache)

## Tests

<details>
<summary>Simple command line tests (click to expand)</summary>

### Script
Command:
```shell
http --all --follow --headers 'http://127.0.0.1:8080/p/script.js'
```
Output
```http
HTTP/1.1 200 OK
Accept-CH: Sec-CH-UA-Platform, Sec-CH-UA
Access-Control-Allow-Origin: *
CDN-Cache: HIT
CDN-CachedAt: 06/08/2026 08:15:07
CDN-EdgeStorageId: 1432
CDN-ProxyVer: 1.55
CDN-PullZone: 682664
CDN-RequestCountryCode: MT
CDN-RequestId: fdd79850f0f5e5a452704e55d73b8a5e
CDN-RequestPullCode: 200
CDN-RequestPullSuccess: True
CDN-RequestTime: 0
CDN-Status: 200
Cache-Control: public, max-age=60, no-transform
Connection: Keep-Alive
Content-Encoding: zstd
Content-Type: application/javascript
Cross-Origin-Resource-Policy: cross-origin
Date: Mon, 08 Jun 2026 08:15:54 GMT
Keep-Alive: timeout=5, max=100
Server: BunnyCDN-IT1-888
Transfer-Encoding: chunked
Vary: Accept-Encoding
Via: 1.1 Caddy
X-Content-Type-Options: nosniff
application: 127.0.0.1
cdn-tag: tracker_script::pa-WRMaH3QHcCo_0RYbTsBgi
permissions-policy: interest-cohort=()
```

### Event
Command:
```shell
http --all --follow --headers post 'http://127.0.0.1:8080/p/api/event'
```
Output
```http
HTTP/1.1 400 Bad Request
Accept-CH: Sec-CH-UA-Platform, Sec-CH-UA
Access-Control-Allow-Credentials: true
Access-Control-Allow-Origin: *
CDN-CachedAt: 06/08/2026 08:20:00
CDN-EdgeStorageId: 1202
CDN-ProxyVer: 1.55
CDN-PullZone: 682664
CDN-RequestCountryCode: MT
CDN-RequestId: 44cec9c7aba724489af550c6405ad677
CDN-RequestPullCode: 400
CDN-RequestPullSuccess: True
CDN-RequestTime: 0
Cache-Control: max-age=0, private, must-revalidate
Connection: close
Content-Length: 94
Content-Type: application/json; charset=utf-8
Date: Mon, 08 Jun 2026 08:20:00 GMT
Server: BunnyCDN-IT1-1202
Via: 1.1 Caddy
X-Request-ID: GLcNTI4R1dOz3Qk1xQoM
application: 127.0.0.1
permissions-policy: interest-cohort=()
```
(400 Bad Request expected due to lack of valid payload)

</details>

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] I have read and understood the Developer Certificate of Origin (DCO), below, which covers the contents of this pull request (PR).
- [x] My pull request doesn't include code or content generated with AI (also see [Avoiding generative AI development tools — Creative Commons Open Source][no-ai]).
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated unit tests and/or test scripts for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[no-ai]: https://opensource.creativecommons.org/blog/entries/2025-12-01-avoiding-gen-ai-tools/
[best_practices]: https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
