### PR TITLE
Secure WordPress includes

### DIFF
--- a/config/web-sites-available/000-default.conf
+++ b/config/web-sites-available/000-default.conf
@@ -202,6 +202,22 @@ ServerName localhost:8080
         RewriteRule . /index.php [L]
     </Directory>
 
+    # Secure includes
+    #
+    # Hardening WordPress – Advanced Administration Handbook |
+    # Developer.WordPress.org
+    # https://developer.wordpress.org/advanced-administration/security/hardening/
+    #
+    # Hardening wordpress: blocking /includes with htaccess - WordPress
+    # Development Stack Exchange
+    # https://wordpress.stackexchange.com/q/156869
+    RewriteRule ^/wp-admin/includes/ - [F,L]
+    RewriteRule !^/wp-includes/ - [S=3]
+    RewriteCond %{REQUEST_URI} !^/wp-includes/ms-files.php$
+    RewriteRule ^/wp-includes\/.*\.php$ - [F,L]
+    RewriteRule ^/wp-includes/js/tinymce/langs/.+\.php - [F,L]
+    RewriteRule ^/wp-includes/theme-compat/ - [F,L]
+
 </VirtualHost>
 
 # vim: ft=apache ts=4 sw=4 sts=4 sr et


### PR DESCRIPTION
<!-- ⚠️ Pull requests (PRs) that don't follow this template will be discarded. -->
## Related
- Related to creativecommons/tech-support/issues/1466 (private repository)

## Description
Secure WordPress includes

## Technical details
-  [Hardening WordPress – Advanced Administration Handbook | Developer.WordPress.org](https://developer.wordpress.org/advanced-administration/security/hardening/)
- [Hardening wordpress: blocking /includes with htaccess - WordPress Development Stack Exchange](https://wordpress.stackexchange.com/q/156869)
- [Rewrite Flags - mod_rewrite - Apache HTTP Server Version 2.4](https://httpd.apache.org/docs/current/mod/mod_rewrite.html#rewriteflags)

## Tests
1. `test_legal_tool_urls.sh` ran without errors
2. manual browsing of dev WordPress

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] I have read and understood the Developer Certificate of Origin (DCO), below, which covers the contents of this pull request (PR).
- [x] My pull request doesn't include code or content generated with AI (also see [Avoiding generative AI development tools — Creative Commons Open Source][no-ai]).
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated unit tests and/or test scripts for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[no-ai]: https://opensource.creativecommons.org/blog/entries/2025-12-01-avoiding-gen-ai-tools/
[best_practices]: https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
