### PR TITLE
Reorganize and expand README (more component info)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,13 @@
 # index-dev-env
 
-Local development environment for CreativeCommons.org (product name: `index`).
+Local development environment for CreativeCommons.org (project name: `index`).
 
 
 ## Overview
 
-This repository has the configuration required to run the CreativeCommons.org
-website in a local Docker development environment.
-
-The CreativeCommons.org website is comprised of five components that are split
-into two categories:
-- dynamic component:
-  - WordPress (Vocabulary Theme)
-- static components:
-  - Chooser
-  - FAQ
-  - Legal Tools (licenses and public domain)
-  - Platform Toolkit
-
-
-### Component repositories
-
-Path label|Path|Component name|Component repositories
-----------|----|--------------|----------------------
-Chooser|`/choose`|Chooser|[chooser][gh-chooser]
-FAQ|`/faq`|FAQ|[faq][gh-faq]
-Licenses| `/licenses`|CC Legal Tools|[cc-legal-tools-app][gh-app], [cc-legal-tools-data][gh-data]
-Platform Toolkit|`/platform/toolkit`|Platform Toolkit|[mp][gh-mp]
-Public Domain|`/publicdomain`|CC Legal Tools|[cc-legal-tools-app][gh-app], [cc-legal-tools-data][gh-data]
-WordPress|`/` (default)|Vocabulary Theme|[vocabulary-theme][gh-vocab-theme]
-
-[gh-chooser]: https://github.com/creativecommons/chooser
-[gh-faq]: https://github.com/creativecommons/faq
-[gh-app]: https://github.com/creativecommons/cc-legal-tools-app
-[gh-data]: https://github.com/creativecommons/cc-legal-tools-data
-[gh-mp]: https://github.com/creativecommons/mp
-[gh-vocab-theme]: https://github.com/creativecommons/vocabulary-theme
+This repository manages the local development environment for
+CreativeCommons.org (project name: `index`). It relies on Docker and requires
+the component repositories.
 
 
 ## Code of conduct
@@ -57,6 +29,81 @@ WordPress|`/` (default)|Vocabulary Theme|[vocabulary-theme][gh-vocab-theme]
 See [`CONTRIBUTING.md`][org-contrib].
 
 [org-contrib]: https://github.com/creativecommons/.github/blob/main/CONTRIBUTING.md
+
+
+## Index components
+
+The CreativeCommons.org website (project name: `index`) is comprised of five
+components that are split into two categories:
+1. Static components
+  - CC Legal Tools ("licenses")
+  - Chooser
+  - FAQ
+  - Platform Toolkit
+2. Dynamic component
+  - WordPress (Vocabulary Theme)
+
+
+### Static component repositories
+
+| Component name | Component repositories |
+| -------------- | ---------------------- |
+| CC Legal Tools | [cc-legal-tools-app][s1], [cc-legal-tools-data][s2] |
+| Chooser | [chooser][s3] |
+| FAQ | [faq][s4] |
+| Platform Toolkit | [mp][s5] |
+
+[s1]: https://github.com/creativecommons/cc-legal-tools-app
+[s2]: https://github.com/creativecommons/cc-legal-tools-data
+[s3]: https://github.com/creativecommons/chooser
+[s4]: https://github.com/creativecommons/faq
+[s5]: https://github.com/creativecommons/mp
+
+
+### Static component URIs
+
+The following URIs and their children/subpaths **mustn't** be used by
+WordPress. They are reserved for the static components:
+| Path | Component name |
+| ---- | -------------- |
+| `/cc-legal-tools` | CC Legal Tools |
+| `/choose` | Chooser |
+| `/chooser` | Chooser |
+| `/faq` | FAQ |
+| `/licence` | CC Legal Tools |
+| `/licences` | CC Legal Tools |
+| `/license` | CC Legal Tools |
+| `/licenses` | CC Legal Tools |
+| `/ns` | CC Legal Tools |
+| `/ns.html` | CC Legal Tools |
+| `/platform` | Platform Toolkit |
+| `/rdf` | CC Legal Tools |
+| `/schema.rdf` | CC Legal Tools |
+
+These URIs are controlled by Apache2 configurations:
+- Dev: [`config/web-sites-available/000-default.conf`][a2conf-dev]
+- Prod: `sre-salt-prime`: [`states/apache2/files/index.conf`][a2conf-prod]
+  - (Also see **Stage and Prod configuration**, below)
+- shared: `cc-legal-tools-data`: [`config/language-redirects`][a2conf-shared]
+
+[a2conf-dev]: config/web-sites-available/000-default.conf
+[a2conf-prod]: https://github.com/creativecommons/sre-salt-prime/blob/main/states/apache2/files/index.conf
+[a2conf-shared]: https://github.com/creativecommons/cc-legal-tools-data/blob/main/config/language-redirects
+
+
+### Dynamic component repository
+
+| Component name | Component repository |
+| -------------- | -------------------- |
+| WordPress      | [vocabulary-theme][d1] |
+
+[d1]: https://github.com/creativecommons/vocabulary-theme
+
+
+### Dynamic component URIs
+
+WordPress is the default handler for URIs. WordPress handles all URIs *except*
+the **Static component URIs**, listed above.
 
 
 ## Docker containers
@@ -113,41 +160,41 @@ containers:
         ```
 
 
-## Path URLs
+## Environment URLs
 
-Path label|Dev link|Stage link|Prod link
-----------|--------|----------|---------
-Chooser|[Dev `/choose`][d1]|[Stage `/choose`][s1]|[Prod `/choose`][p1]
-FAQ|[Dev `/faq`][d2]|[Stage `/faq`][s2]|[Prod `/faq`][p2]
-Licenses|[Dev `/licenses`][d3]|[Stage `/licenses`][s3]|[Prod `/licenses`][p3]
-Platform Toolkit|[Dev `/platform/toolkit`][d4]|[Stage `/platform/toolkit`][s4]|[Prod `/platform/toolkit`][p4]
-Public Domain|[Dev `/publicdomain`][d5]|[Stage `/publicdomain`][s5]|[Prod `/publicdomain`][p5]
-WordPress|[Dev `/` (default)][d6]|[Stage `/` (default)][s6]|[Prod `/` (default)][p6]
-WordPress Admin|[Dev `/wp-admin`][d7]|[Stage `/wp-admin`][s7]|[Prod `/wp-admin`][p7]
+| Path label | Dev link | Stage link | Prod link |
+| ---------- | -------- | ---------- | --------- |
+| Chooser | [Dev `/choose`][a1] | [Stage `/choose`][b1] | [Prod `/choose`][c1] |
+| FAQ | [Dev `/faq`][a2] | [Stage `/faq`][b2] | [Prod `/faq`][c2] |
+| Licenses | [Dev `/licenses`][a3] | [Stage `/licenses`][b3] | [Prod `/licenses`][c3] |
+| Platform Toolkit | [Dev `/platform/toolkit`][a4] | [Stage `/platform/toolkit`][b4] | [Prod `/platform/toolkit`][c4] |
+| Public Domain | [Dev `/publicdomain`][a5] | [Stage `/publicdomain`][b5] | [Prod `/publicdomain`][c5] |
+| WordPress | [Dev `/` (default)][a6] | [Stage `/` (default)][b6] | [Prod `/` (default)][c6] |
+| WordPress Admin | [Dev `/wp-admin`][a7] | [Stage `/wp-admin`][b7] | [Prod `/wp-admin`][c7] |
 
-[d1]: http://localhost:8080/choose "Dev Chooser /choose"
-[d2]: http://localhost:8080/faq "Dev FAQ /faq"
-[d3]: http://localhost:8080/licenses "Dev Licenses /licenses"
-[d4]: http://localhost:8080/platform/toolkit "Dev Platform Toolkit /platform/toolkit"
-[d5]: http://localhost:8080/publicdomain "Dev Public Domain /publicdomain"
-[d6]: http://localhost:8080/ "Dev WordPress / (default)"
-[d7]: http://localhost:8080/wp-admin/ "Dev WordPress Admin /wp-admin"
+[a1]: http://localhost:8080/choose "Dev Chooser /choose"
+[a2]: http://localhost:8080/faq "Dev FAQ /faq"
+[a3]: http://localhost:8080/licenses "Dev Licenses /licenses"
+[a4]: http://localhost:8080/platform/toolkit "Dev Platform Toolkit /platform/toolkit"
+[a5]: http://localhost:8080/publicdomain "Dev Public Domain /publicdomain"
+[a6]: http://localhost:8080/ "Dev WordPress / (default)"
+[a7]: http://localhost:8080/wp-admin/ "Dev WordPress Admin /wp-admin"
 
-[s1]: https://stage.creativecommons.org/choose "Stage Chooser /choose"
-[s2]: https://stage.creativecommons.org/faq "Stage FAQ /faq"
-[s3]: https://stage.creativecommons.org/licenses "Stage Licenses /licenses"
-[s4]: https://stage.creativecommons.org/platform/toolkit "Stage Platform Toolkit /platform/toolkit"
-[s5]: https://stage.creativecommons.org/publicdomain "Stage Public Domain /publicdomain"
-[s6]: https://stage.creativecommons.org/ "Stage WordPress / (default)"
-[s7]: https://stage.creativecommons.org/wp-admin/ "Stage WordPress Admin /wp-admin"
+[b1]: https://stage.creativecommons.org/choose "Stage Chooser /choose"
+[b2]: https://stage.creativecommons.org/faq "Stage FAQ /faq"
+[b3]: https://stage.creativecommons.org/licenses "Stage Licenses /licenses"
+[b4]: https://stage.creativecommons.org/platform/toolkit "Stage Platform Toolkit /platform/toolkit"
+[b5]: https://stage.creativecommons.org/publicdomain "Stage Public Domain /publicdomain"
+[b6]: https://stage.creativecommons.org/ "Stage WordPress / (default)"
+[b7]: https://stage.creativecommons.org/wp-admin/ "Stage WordPress Admin /wp-admin"
 
-[p1]: https://creativecommons.org/choose "Prod Chooser /choose"
-[p2]: https://creativecommons.org/faq "Prod FAQ /faq"
-[p3]: https://creativecommons.org/licenses "Prod Licenses /licenses"
-[p4]: https://creativecommons.org/platform/toolkit "Prod Platform Toolkit /platform/toolkit"
-[p5]: https://creativecommons.org/publicdomain "Prod Public Domain /publicdomain"
-[p6]: https://creativecommons.org/ "Prod WordPress / (default)"
-[p7]: https://creativecommons.org/wp-admin/ "Prod WordPress Admin /wp-admin"
+[c1]: https://creativecommons.org/choose "Prod Chooser /choose"
+[c2]: https://creativecommons.org/faq "Prod FAQ /faq"
+[c3]: https://creativecommons.org/licenses "Prod Licenses /licenses"
+[c4]: https://creativecommons.org/platform/toolkit "Prod Platform Toolkit /platform/toolkit"
+[c5]: https://creativecommons.org/publicdomain "Prod Public Domain /publicdomain"
+[c6]: https://creativecommons.org/ "Prod WordPress / (default)"
+[c7]: https://creativecommons.org/wp-admin/ "Prod WordPress Admin /wp-admin"
 
 
 ## Dev configuration
@@ -163,8 +210,8 @@ See [`config/web-sites-available/000-default.conf`][dev-webconfig].
 ### WordPress core
 
 | Name      | Version |
-| --------- | ------- |
-| WordPress | `6.3.1`   |
+| --------- | :-----: |
+| WordPress | `6.3.1` |
 
 Also see [`.env.example`](.env.example).
 
@@ -172,7 +219,7 @@ Also see [`.env.example`](.env.example).
 ### WordPress plugins
 
 | Name                                                     | Version  |
-| -------------------------------------------------------- | -------- |
+| -------------------------------------------------------- | :------: |
 | [Advanced Custom Fields][adv-custom-fields]              | `6.2.1`  |
 | [Advanced Custom Fields: Menu Chooser][acf-menu-chooser] | `1.1.0`  |
 | [Classic Editor][classic-editor]                         | `1.6.3`  |
@@ -199,33 +246,35 @@ Also see [`config/composer/composer.json`](config/composer/composer.json).
 ### WordPress themes
 
 | Name                                 | Version  |
-| ------------------------------------ | -------- |
-| [Vocabulary Theme][gh-vocab-theme]   | `2.6.3`    |
+| ------------------------------------ | :------: |
+| [Vocabulary Theme][gh-vocab-theme]   | `2.6.3`  |
 
 Also see [`config/composer/composer.json`](config/composer/composer.json).
 
+
 ### vocabulary-theme QA Checklist
+
 <details>
-<summary> vocabulary-theme release testing QA checklist</summary>
+<summary>vocabulary-theme release testing QA checklist (click to expand)</summary>
 
 1. run setup-wp script (again to make sure WP is current version)
 2. be sure to clear/disable caches locally
 3. review any new context/template/page
 4. review pages:
-    - [home-page](http://localhost:8080/) 
-    - [sub-page](http://localhost:8080/about)
-    - [team-index](http://localhost:8080/mission/team)
-    - [search-index](http://localhost:8080/?s)
-    - [archive-page](http://localhost:8080/blog/archive)
-    - [blog-index](http://localhost:8080/blog)
-    - [blog-post](http://localhost:8080/2025/03/03/from-strategy-to-action-focus-areas-for-2025/)
-    - [faq](http://localhost:8080/faq)
-    - [mp](http://localhost:8080/platform/toolkit/)
-    - [licenses list](http://localhost:8080/licenses)
-    - [license deed | EN](http://localhost:8080/licenses/by/4.0/)
-    - [license legal code | EN](http://localhost:8080/licenses/by/4.0/legalcode.en)
-    - [license deed | AR](http://localhost:8080/licenses/by/4.0/deed.ar)
-    - [license legal code | AR](http://localhost:8080/licenses/by/4.0/legalcode.ar)
+   - [home-page](http://localhost:8080/)
+   - [sub-page](http://localhost:8080/about)
+   - [team-index](http://localhost:8080/mission/team)
+   - [search-index](http://localhost:8080/?s)
+   - [archive-page](http://localhost:8080/blog/archive)
+   - [blog-index](http://localhost:8080/blog)
+   - [blog-post](http://localhost:8080/2025/03/03/from-strategy-to-action-focus-areas-for-2025/)
+   - [faq](http://localhost:8080/faq)
+   - [mp](http://localhost:8080/platform/toolkit/)
+   - [licenses list](http://localhost:8080/licenses)
+   - [license deed | EN](http://localhost:8080/licenses/by/4.0/)
+   - [license legal code | EN](http://localhost:8080/licenses/by/4.0/legalcode.en)
+   - [license deed | AR](http://localhost:8080/licenses/by/4.0/deed.ar)
+   - [license legal code | AR](http://localhost:8080/licenses/by/4.0/legalcode.ar)
 
 </details>
 


### PR DESCRIPTION
<!-- ⚠️ Pull requests (PRs) that don't follow this template will be discarded. -->
## Description
Reorganize and expand README
- Reorganize sections
- Add additional component information
- minor formatting updates
- Rendered READMEs
  - [Old README.md](https://github.com/creativecommons/index-dev-env/blob/efa6ee0dd146da8cd94d06fe405b8e9cfc6bd949/README.md)
  - [New README.md](https://github.com/creativecommons/index-dev-env/blob/6168ceee4048ac756ae0db0903a38b122f271c81/README.md)

<!--
## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->

<!--
## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] I have read and understood the Developer Certificate of Origin (DCO), below, which covers the contents of this pull request (PR).
- [x] My pull request doesn't include code or content generated with AI (also see [Avoiding generative AI development tools — Creative Commons Open Source][no-ai]).
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated unit tests and/or test scripts for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[no-ai]: https://opensource.creativecommons.org/blog/entries/2025-12-01-avoiding-gen-ai-tools/
[best_practices]: https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
