### PR TITLE
Improve accuracy and reliability of legacy/compatibility redirects

### DIFF
--- a/config/web-sites-available/000-default.conf
+++ b/config/web-sites-available/000-default.conf
@@ -72,9 +72,12 @@ ServerName localhost:8080
     RewriteCond %{REQUEST_URI} [A-Z]
     RewriteRule ^(.*)$ ${lowercase:$1} [R=301,L]
     # Legacy/compatibilty redirects
-    RewriteRule  /license(/|$)   /licenses/  [R=301]
-    RewriteRule  /licences(/|$)  /licenses/  [R=301]
-    RewriteRule  /licence(/|$)   /licenses/  [R=301]
+    RedirectMatch 301   /licence$   /licenses/
+    RedirectPermanent   /licence/   /licenses/
+    RedirectMatch 301   /licences$  /licenses/
+    RedirectPermanent   /licences/  /licenses/
+    RedirectMatch 301   /license$   /licenses/
+    RedirectPermanent   /license/   /licenses/
     <Directory /var/www/git/cc-legal-tools-data/docs>
         Options -Indexes
         # Disable .htaccess (for security and performance)


### PR DESCRIPTION
<!-- ⚠️ Pull requests (PRs) that don't follow this template will be discarded. -->
## Description
Improve accuracy and reliability of legacy/compatibility redirects

## Technical details
- [mod_alias - Apache HTTP Server Version 2.4](https://httpd.apache.org/docs/2.4/mod/mod_alias.html)
- [mod_rewrite - Apache HTTP Server Version 2.4](https://httpd.apache.org/docs/current/mod/mod_rewrite.html#rewritecond)
- [Apache mod_rewrite Technical Details - Apache HTTP Server Version 2.4](https://httpd.apache.org/docs/current/rewrite/tech.html)

## Tests
Tested using [`test_legal_tool_urls.sh`](https://github.com/creativecommons/index-dev-env/blob/efa6ee0dd146da8cd94d06fe405b8e9cfc6bd949/test_legal_tool_urls.sh).

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] I have read and understood the Developer Certificate of Origin (DCO), below, which covers the contents of this pull request (PR).
- [x] My pull request doesn't include code or content generated with AI (also see [Avoiding generative AI development tools — Creative Commons Open Source][no-ai]).
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated unit tests and/or test scripts for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[no-ai]: https://opensource.creativecommons.org/blog/entries/2025-12-01-avoiding-gen-ai-tools/
[best_practices]: https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
